### PR TITLE
feat: HANDOFF rev 3 — payment persistence + webhooks + tests (P1 #2.2-2.4, P2 #2.5/2.7)

### DIFF
--- a/HANDOFF-PLAN.md
+++ b/HANDOFF-PLAN.md
@@ -1,26 +1,29 @@
 # ADVE-project — Plan d'actions restantes
 
-**Date** : 2026-04-27 (revision 2)
+**Date** : 2026-04-27 (revision 3)
 **Repo canonique** : `https://github.com/xtincell/ADVE-project` — branche `main`
-**Version** : 4.0.0-alpha (consolidation v3 + v4 + paywall + Notoria wiring)
-**Tests** : 672 unit pass, 22 LLM smoke (requiert ANTHROPIC_API_KEY)
+**Version** : 4.0.0-alpha (consolidation v3 + v4 + paywall + Notoria wiring + payment persistence)
+**Tests** : 704 unit pass, 22 LLM smoke (requiert ANTHROPIC_API_KEY)
 **Build** : 164 pages compilees, 0 erreur TS
 
 ---
 
-## CHANGELOG DEPUIS REVISION 1
+## CHANGELOG DEPUIS REVISION 2
 
-### Ajouts (commit en cours)
-- **P0.1 Paywall** : router `payment.ts` (CinetPay + Stripe + mock dev), gating sur recos Notoria + PDF
-- **P0.2 Notoria wiring** : `complete()` declenche `generateBatch({ missionType: "ADVE_UPDATE", targetPillars: ["a","d","v","e"] })` en best-effort
-- **P0.3 CTAs fonctionnels** : `mailto:` remplaces par `/onboarding?intake=:token`, PDF gated par paywall
-- **getRecosByToken** : nouveau endpoint tRPC qui retourne 2 recos en preview gratuit / toutes en mode paye
-- **.gitignore** : runtime logs (`*.log`, `logs/`) + Finder/iCloud duplicates (`* 2.{ts,tsx,js,jsx,json}`) ignores
+### Ajouts (revision 3)
+- **P1 #2.2 Webhooks paiement** : `/api/payment/webhook/cinetpay` (HMAC `x-token` + double-check via API CinetPay v2) et `/api/payment/webhook/stripe` (signature `t/v1` + tolerance 5min, comparaison constant-time, scope `checkout.session.completed`)
+- **P1 #2.3 Persistance paiement** : nouveau modele Prisma `IntakePayment` (+ enums `IntakePaymentProvider/Currency/Status`), `payment.ts` migre du Map en memoire vers `db.intakePayment`
+- **P1 #2.4 Notoria lifecycle** : `scripts/test-notoria-lifecycle.ts` (headless tsx) verifie pendingRecos → accept → apply → pillar update sur le seed Wakanda
+- **P2 #2.5 Tests connecteurs** : `tests/unit/services/advertis-connectors.test.ts` (15 tests Monday/Zoho/MCP advertis-inbound, pure mapping, no DB)
+- **P2 #2.7 Tests LLM gateway** : `tests/unit/services/llm-gateway.test.ts` (17 tests extractJSON + withRetry)
+- **Demo data** : `src/server/services/demo-data/` (getDemoMode) + wiring dans `operator-isolation.scopeStrategies` (hide_dummy / only_dummy) + `advertis-scorer.snapshotAllStrategies` exclut `isDummy=true`
+- **Wakanda seed** : `scripts/seed-wakanda/` (6 brands, 844 records, 38 piliers, 68 recos en mix de statuts)
 
 ### Verifie
-- `npx tsc --noEmit` : **0 erreur** (le HANDOFF v1 mentionnait 1402 erreurs, c'etait avant le merge v3+v4 en main)
-- `npx vitest run` (unit) : **672/672 pass**
-- `npx next build` : **OK, 164 pages**
+- `npx tsc --noEmit` : **0 erreur**
+- `npx vitest run` (unit) : **704/704 pass** (672 + 32 nouveaux)
+- `npx prisma db push` : applique la table `IntakePayment` (idempotent)
+- `npx tsx scripts/test-notoria-lifecycle.ts` : 3 recos PENDING → ACCEPTED → APPLIED, pillar `a` mute
 
 ---
 
@@ -76,46 +79,38 @@ Feedback-loop, knowledge-capture, mestor governance OK.
 ```env
 CINETPAY_API_KEY=...
 CINETPAY_SITE_ID=...
+CINETPAY_SECRET_KEY=...        # Pour HMAC du webhook
 STRIPE_SECRET_KEY=...
+STRIPE_WEBHOOK_SECRET=whsec_... # Pour signature Stripe
 ANTHROPIC_API_KEY=sk-ant-...
 ```
-En dev sans cles, le paywall passe en mode `MOCK` qui auto-confirme le paiement (utile pour les tests UI).
+En dev sans cles, le paywall passe en mode `MOCK` qui auto-confirme le paiement.
 
-#### 2.2 Webhooks de paiement (separe du flow synchrone)
-Routes API a creer :
-- `/api/payment/webhook/cinetpay` — confirme/rejette le paiement
-- `/api/payment/webhook/stripe` — meme chose
+#### ~~2.2 Webhooks de paiement~~ — **DONE en revision 3**
+Routes implementees, signatures verifiees avec HMAC constant-time. Configurer cote provider :
+- CinetPay : notify_url = `https://<domain>/api/payment/webhook/cinetpay`
+- Stripe : webhook endpoint = `https://<domain>/api/payment/webhook/stripe`, evenement = `checkout.session.completed`
 
-Actuellement le router `payment.ts` redirige vers le provider, et la confirmation se fait au retour via `?ref=xxx&status=paid` + `verifyPayment` query. Pour la production, ajouter les webhooks pour la double-verification.
+#### ~~2.3 Persister les paiements en DB~~ — **DONE en revision 3**
+Modele `IntakePayment` cree, router migre. **Action restante** : exposer un endpoint admin pour lister les paiements (pas urgent — Prisma Studio fait l'affaire en interim).
 
-#### 2.3 Persister les paiements en DB
-Le router `payment.ts` utilise un store en memoire (`pendingPayments` Map). En production :
-- Ajouter un modele Prisma `Payment` (reference, intakeId, amount, currency, provider, status, createdAt, paidAt)
-- Migrer le store en memoire vers la DB
-- Ajouter un endpoint admin pour lister les paiements
-
-#### 2.4 Notoria/Jehuty UI — verifier le flow complet
-- `notoria-page.tsx` (523 lignes) et `jehuty-feed-page.tsx` (310 lignes) existent
-- Routes cockpit : `/cockpit/brand/notoria`, `/cockpit/brand/jehuty`
-- Tester le flow : pendingRecos → accept/reject → apply → pillar update
+#### ~~2.4 Notoria headless~~ — **DONE en revision 3**
+Test tsx valide le lifecycle. **Action restante** : tester le flow UI cockpit complet (`/cockpit/brand/notoria`, `/cockpit/brand/jehuty`) en navigateur reel — bloque dans la sandbox actuelle (Turbopack tente de bundler les fonts Google).
 
 ---
 
 ### P2 — Amelioration
 
-#### 2.5 Connectors externes
-- Monday.com et Zoho adapters existent
-- MCP advertis-inbound endpoint existe
-- Aucun n'est teste — ajouter des tests unitaires
+#### ~~2.5 Tests connectors externes~~ — **DONE en revision 3**
 
 #### 2.6 Landing page
 - Composants existent (hero, navbar, pricing, FAQ, footer, social-proof, etc.)
 - `src/app/page.tsx` assemble bien les composants
+- Pas de test de regression visuel actuellement
 
-#### 2.7 LLM fallback robuste
-- `llm-gateway/index.ts` supporte multi-vendor (Anthropic + OpenAI + Ollama)
-- Circuit breaker actif (3 echecs → 30s open)
-- Verifier la cascade quand pas de cle API
+#### ~~2.7 LLM gateway~~ — **PARTIELLEMENT DONE en revision 3**
+- Tests unit pour `extractJSON` + `withRetry` ajoutes (17 cas).
+- **Action restante** : ajouter une fonction `_resetProvidersForTest()` (export interne) pour tester la cascade multi-vendor + circuit breaker en isolation.
 
 ---
 

--- a/scripts/test-notoria-lifecycle.ts
+++ b/scripts/test-notoria-lifecycle.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env tsx
+/**
+ * NOTORIA Lifecycle Headless Test (HANDOFF #2.4)
+ *
+ * Exercises pendingRecos → accept → apply → pillar update on the
+ * Wakanda demo dataset (vibranium has 15 PENDING by design).
+ *
+ * Run:  npx tsx scripts/test-notoria-lifecycle.ts
+ */
+
+import { db } from "../src/lib/db";
+import { acceptRecos, applyRecos } from "../src/server/services/notoria/lifecycle";
+
+const REVIEWER_ID = "wk-user-mestor"; // Wakanda admin from seed
+
+async function main() {
+  console.log("═══ NOTORIA LIFECYCLE TEST (Wakanda demo) ═══\n");
+
+  // ── 1. Inventory: find a demo strategy with PENDING recos ──
+  const demoStrategyIds = (await db.strategy.findMany({
+    where: { isDummy: true },
+    select: { id: true },
+  })).map((s) => s.id);
+  const candidates = await db.recommendation.groupBy({
+    by: ["strategyId"],
+    where: { strategyId: { in: demoStrategyIds }, status: "PENDING" },
+    _count: true,
+    orderBy: { _count: { strategyId: "desc" } },
+  });
+  if (candidates.length === 0) {
+    console.error("❌ No demo strategy has PENDING recos. Did you run the Wakanda seed?");
+    process.exit(1);
+  }
+  const target = candidates[0];
+  const strategy = await db.strategy.findUniqueOrThrow({
+    where: { id: target.strategyId },
+    select: { id: true, name: true },
+  });
+  console.log(`1. Target: ${strategy.name} (${strategy.id}) — ${target._count} PENDING\n`);
+
+  // ── 2. Pick 3 PENDING recos to push through the lifecycle ──
+  const sample = await db.recommendation.findMany({
+    where: { strategyId: strategy.id, status: "PENDING" },
+    select: { id: true, targetPillarKey: true, targetField: true, operation: true },
+    take: 3,
+  });
+  console.log("2. Sample PENDING (3):");
+  for (const r of sample) console.log(`   - ${r.id}  ${r.operation} ${r.targetPillarKey}.${r.targetField}`);
+  const recoIds = sample.map((r) => r.id);
+
+  // ── 3. acceptRecos ──
+  const accepted = await acceptRecos(strategy.id, recoIds, REVIEWER_ID);
+  console.log(`\n3. acceptRecos: ${accepted.accepted}/${recoIds.length}`);
+  if (accepted.accepted !== recoIds.length) {
+    console.error("❌ acceptRecos failed");
+    process.exit(1);
+  }
+  const stillPending = await db.recommendation.count({
+    where: { id: { in: recoIds }, status: "PENDING" },
+  });
+  const nowAccepted = await db.recommendation.count({
+    where: { id: { in: recoIds }, status: "ACCEPTED" },
+  });
+  console.log(`   PENDING→ACCEPTED transition: pending=${stillPending}, accepted=${nowAccepted}`);
+
+  // ── 4. Capture pillar content BEFORE apply ──
+  const pillarKeys = [...new Set(sample.map((r) => r.targetPillarKey))];
+  const before = await db.pillar.findMany({
+    where: { strategyId: strategy.id, key: { in: pillarKeys } },
+    select: { key: true, content: true, completionLevel: true },
+  });
+
+  // ── 5. applyRecos ──
+  const applied = await applyRecos(strategy.id, recoIds);
+  console.log(`\n5. applyRecos: applied=${applied.applied}, warnings=${applied.warnings.length}`);
+  if (applied.warnings.length > 0) {
+    for (const w of applied.warnings) console.log(`   ⚠ ${w}`);
+  }
+
+  // ── 6. Verify status transition + pillar content delta ──
+  const finalStatus = await db.recommendation.groupBy({
+    by: ["status"],
+    where: { id: { in: recoIds } },
+    _count: true,
+  });
+  console.log("\n6. Final reco status:");
+  for (const s of finalStatus) console.log(`   ${s.status}: ${s._count}`);
+
+  const after = await db.pillar.findMany({
+    where: { strategyId: strategy.id, key: { in: pillarKeys } },
+    select: { key: true, content: true, completionLevel: true },
+  });
+  console.log("\n7. Pillar content delta:");
+  for (const a of after) {
+    const b = before.find((x) => x.key === a.key);
+    const beforeJson = JSON.stringify(b?.content ?? {});
+    const afterJson = JSON.stringify(a.content ?? {});
+    const changed = beforeJson !== afterJson;
+    console.log(
+      `   ${a.key}: completion ${b?.completionLevel ?? "?"} → ${a.completionLevel ?? "?"}, content ${changed ? "CHANGED" : "unchanged"}`,
+    );
+  }
+
+  // ── 7. Acceptance criteria ──
+  const allApplied = finalStatus.every((s) => s.status === "APPLIED");
+  if (!allApplied) {
+    console.error("\n❌ Some recos are not APPLIED — flow incomplete.");
+    process.exit(1);
+  }
+  console.log("\n═══ ✅ LIFECYCLE PASS ═══");
+  await db.$disconnect();
+}
+
+main().catch((err) => {
+  console.error("❌", err);
+  process.exit(1);
+});

--- a/tests/unit/services/advertis-connectors.test.ts
+++ b/tests/unit/services/advertis-connectors.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "vitest";
+import { MondayConnector } from "@/server/services/advertis-connectors/monday";
+import { ZohoConnector } from "@/server/services/advertis-connectors/zoho";
+import { tools as advertisInboundTools } from "@/server/mcp/advertis-inbound";
+import { PillarSignalSchema } from "@/lib/types/pillar-signal";
+
+// ---------------------------------------------------------------------------
+// Pure mapping logic — no DB, no network, no env
+// ---------------------------------------------------------------------------
+
+describe("MondayConnector.mapEventToSignals", () => {
+  const monday = new MondayConnector();
+
+  function item(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "item-1",
+      name: "Implement feature X",
+      state: "active",
+      updated_at: new Date().toISOString(),
+      column_values: [],
+      board: { id: "board-1", name: "Sprint board" },
+      ...overrides,
+    };
+  }
+
+  it("status_change to 'Done' emits velocity signal on pillar e", () => {
+    const signals = monday.mapEventToSignals({
+      eventType: "status_change",
+      item: item({
+        column_values: [
+          { id: "c1", title: "Status", type: "status", text: "Done", value: null },
+        ],
+      }),
+    });
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0].pillarKey).toBe("e");
+    expect(signals[0].driver).toBe("monday-velocity");
+    expect(signals[0].source).toBe("EXTERNAL_SAAS");
+    expect(signals[0].externalRef).toBe("monday:item:item-1");
+    expect(PillarSignalSchema.safeParse(signals[0]).success).toBe(true);
+  });
+
+  it("status_change with French 'terminé' is detected as done", () => {
+    const signals = monday.mapEventToSignals({
+      eventType: "status_change",
+      item: item({
+        column_values: [
+          { id: "c1", title: "Statut", type: "status", text: "Terminé", value: null },
+        ],
+      }),
+    });
+    expect(signals).toHaveLength(1);
+    expect(signals[0].pillarKey).toBe("e");
+  });
+
+  it("status_change to 'In Progress' emits no signal", () => {
+    const signals = monday.mapEventToSignals({
+      eventType: "status_change",
+      item: item({
+        column_values: [
+          { id: "c1", title: "Status", type: "status", text: "In Progress", value: null },
+        ],
+      }),
+    });
+    expect(signals).toHaveLength(0);
+  });
+
+  it("timeline_overdue with past date emits blocker signal on pillar r with daysLate", () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const signals = monday.mapEventToSignals({
+      eventType: "timeline_overdue",
+      item: item({
+        column_values: [
+          { id: "c2", title: "Timeline", type: "timeline", text: "", value: JSON.stringify({ to: tenDaysAgo }) },
+        ],
+      }),
+    });
+    expect(signals).toHaveLength(1);
+    expect(signals[0].pillarKey).toBe("r");
+    expect(signals[0].driver).toBe("monday-blocker");
+    const value = signals[0].value as { daysLate: number };
+    expect(value.daysLate).toBeGreaterThanOrEqual(9);
+  });
+
+  it("timeline_overdue with future date emits no signal", () => {
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const signals = monday.mapEventToSignals({
+      eventType: "timeline_overdue",
+      item: item({
+        column_values: [
+          { id: "c2", title: "Timeline", type: "timeline", text: "", value: JSON.stringify({ to: tomorrow }) },
+        ],
+      }),
+    });
+    expect(signals).toHaveLength(0);
+  });
+
+  it("wip_snapshot emits WIP signal on pillar s with parsed count", () => {
+    const signals = monday.mapEventToSignals({
+      eventType: "wip_snapshot",
+      item: item({
+        column_values: [
+          { id: "c3", title: "WIP", type: "numbers", text: "7", value: null },
+        ],
+      }),
+    });
+    expect(signals).toHaveLength(1);
+    expect(signals[0].pillarKey).toBe("s");
+    expect(signals[0].driver).toBe("monday-wip");
+    expect((signals[0].value as { wipCount: number }).wipCount).toBe(7);
+  });
+
+  it("wip_snapshot with missing column defaults wipCount to 0", () => {
+    const signals = monday.mapEventToSignals({
+      eventType: "wip_snapshot",
+      item: item({ column_values: [] }),
+    });
+    expect((signals[0].value as { wipCount: number }).wipCount).toBe(0);
+  });
+});
+
+describe("ZohoConnector.mapEventToSignals", () => {
+  const zoho = new ZohoConnector();
+
+  function deal(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "deal-42",
+      Deal_Name: "Acme — POC",
+      Stage: "Qualification",
+      Amount: 5000,
+      Probability: 30,
+      Closing_Date: "2026-06-01",
+      Modified_Time: "2026-04-27 12:00:00",
+      Owner: { id: "user-1", name: "Sales Rep" },
+      ...overrides,
+    };
+  }
+
+  it("deal_won emits high-confidence verified signal on pillar t", () => {
+    const signals = zoho.mapEventToSignals({
+      eventType: "deal_won",
+      deal: deal({ Stage: "Closed Won", Amount: 12000 }),
+    });
+    expect(signals).toHaveLength(1);
+    expect(signals[0].pillarKey).toBe("t");
+    expect(signals[0].driver).toBe("zoho-conversion");
+    expect(signals[0].confidence).toBe(0.85);
+    expect((signals[0].value as { amount: number }).amount).toBe(12000);
+    expect(PillarSignalSchema.safeParse(signals[0]).success).toBe(true);
+  });
+
+  it("deal_lost emits loss signal on pillar r with reason", () => {
+    const signals = zoho.mapEventToSignals({
+      eventType: "deal_lost",
+      deal: deal({ Stage: "Closed Lost", Lost_Reason: "Budget" }),
+    });
+    expect(signals).toHaveLength(1);
+    expect(signals[0].pillarKey).toBe("r");
+    expect(signals[0].driver).toBe("zoho-loss");
+    expect((signals[0].value as { reason: string }).reason).toBe("Budget");
+  });
+
+  it("deal_lost without Lost_Reason falls back to 'Non spécifié'", () => {
+    const signals = zoho.mapEventToSignals({
+      eventType: "deal_lost",
+      deal: deal({ Stage: "Closed Lost", Lost_Reason: undefined }),
+    });
+    expect((signals[0].value as { reason: string }).reason).toBe("Non spécifié");
+  });
+
+  it("stage_change emits pipeline signal on pillar v with stage + amount + probability", () => {
+    const signals = zoho.mapEventToSignals({
+      eventType: "stage_change",
+      deal: deal({ Stage: "Negotiation", Amount: 8000, Probability: 75 }),
+    });
+    expect(signals).toHaveLength(1);
+    expect(signals[0].pillarKey).toBe("v");
+    expect(signals[0].driver).toBe("zoho-pipeline");
+    const v = signals[0].value as { stage: string; probability: number };
+    expect(v.stage).toBe("Negotiation");
+    expect(v.probability).toBe(75);
+  });
+
+  it("amount=null defaults to 0 in emitted signal", () => {
+    const signals = zoho.mapEventToSignals({
+      eventType: "deal_won",
+      deal: deal({ Amount: null, Stage: "Closed Won" }),
+    });
+    expect((signals[0].value as { amount: number }).amount).toBe(0);
+  });
+});
+
+describe("advertis-inbound MCP tools", () => {
+  it("exposes the four expected tools", () => {
+    const names = advertisInboundTools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "getConnectorStatus",
+      "ingestBatch",
+      "ingestPillarSignal",
+      "listPillarMappings",
+    ]);
+  });
+
+  it("listPillarMappings returns Monday + Zoho mappings", async () => {
+    const tool = advertisInboundTools.find((t) => t.name === "listPillarMappings");
+    expect(tool).toBeDefined();
+    const result = (await tool!.handler({})) as {
+      pillarKeys: readonly string[];
+      supportedConnectors: { type: string; mappings: { pillarKey: string; driver: string }[] }[];
+    };
+
+    const mondayDrivers = result.supportedConnectors
+      .find((c) => c.type === "monday")!
+      .mappings.map((m) => m.driver);
+    expect(mondayDrivers).toContain("monday-velocity");
+    expect(mondayDrivers).toContain("monday-blocker");
+    expect(mondayDrivers).toContain("monday-wip");
+
+    const zohoDrivers = result.supportedConnectors
+      .find((c) => c.type === "zoho")!
+      .mappings.map((m) => m.driver);
+    expect(zohoDrivers).toContain("zoho-pipeline");
+    expect(zohoDrivers).toContain("zoho-conversion");
+    expect(zohoDrivers).toContain("zoho-loss");
+
+    // Every mapping pillarKey must be a valid PILLAR_KEYS entry
+    for (const conn of result.supportedConnectors) {
+      for (const m of conn.mappings) {
+        expect(result.pillarKeys).toContain(m.pillarKey);
+      }
+    }
+  });
+
+  it("ingestPillarSignal tool has a Zod input schema that validates a sample signal", () => {
+    const tool = advertisInboundTools.find((t) => t.name === "ingestPillarSignal");
+    expect(tool).toBeDefined();
+    const sample = {
+      pillarKey: "e",
+      driver: "monday-velocity",
+      value: { completed: true },
+      source: "EXTERNAL_SAAS",
+      confidence: 0.7,
+      strategyId: "strategy-1",
+    };
+    expect(tool!.inputSchema.safeParse(sample).success).toBe(true);
+  });
+});

--- a/tests/unit/services/llm-gateway.test.ts
+++ b/tests/unit/services/llm-gateway.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from "vitest";
+import { extractJSON, withRetry } from "@/server/services/llm-gateway";
+
+// ---------------------------------------------------------------------------
+// extractJSON — robust 3-step parser
+// ---------------------------------------------------------------------------
+
+describe("extractJSON", () => {
+  it("parses pure JSON object", () => {
+    const result = extractJSON('{"foo": "bar", "n": 42}');
+    expect(result).toEqual({ foo: "bar", n: 42 });
+  });
+
+  it("parses pure JSON array", () => {
+    const result = extractJSON('[1, 2, 3]');
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it("parses JSON wrapped in markdown ```json fences", () => {
+    const text = "Here is your answer:\n```json\n{\"score\": 7}\n```\nHope this helps!";
+    expect(extractJSON(text)).toEqual({ score: 7 });
+  });
+
+  it("parses JSON wrapped in plain ``` fences (no language tag)", () => {
+    const text = "```\n{\"a\": 1}\n```";
+    expect(extractJSON(text)).toEqual({ a: 1 });
+  });
+
+  it("extracts JSON from prose with leading text", () => {
+    const text = 'Sure, here you go: {"verdict": "good", "confidence": 0.8}';
+    expect(extractJSON(text)).toEqual({ verdict: "good", confidence: 0.8 });
+  });
+
+  it("handles nested objects with balanced braces inside strings", () => {
+    const text = '{"msg": "use { and } carefully", "nested": {"inner": true}}';
+    expect(extractJSON(text)).toEqual({
+      msg: "use { and } carefully",
+      nested: { inner: true },
+    });
+  });
+
+  it("handles escaped quotes in strings", () => {
+    const text = '{"quote": "he said \\"hi\\" loudly"}';
+    expect(extractJSON(text)).toEqual({ quote: 'he said "hi" loudly' });
+  });
+
+  it("prefers object over array when both appear (object first)", () => {
+    const text = '{"first": true} and then [1,2,3]';
+    expect(extractJSON(text)).toEqual({ first: true });
+  });
+
+  it("picks array if it appears before object", () => {
+    const text = "preface [10, 20] then {\"after\": true}";
+    expect(extractJSON(text)).toEqual([10, 20]);
+  });
+
+  it("throws when no valid JSON is present", () => {
+    expect(() => extractJSON("just plain text, no JSON here")).toThrow(/impossible de parser/i);
+  });
+
+  it("throws on unbalanced braces", () => {
+    expect(() => extractJSON("starting { but never closing")).toThrow();
+  });
+
+  it("rejects valid JSON primitives (numbers, strings) — only objects/arrays allowed", () => {
+    // A bare number IS valid JSON, but the gateway promises Record<string, unknown> | unknown[]
+    expect(() => extractJSON("42")).toThrow();
+    expect(() => extractJSON('"just a string"')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withRetry — exponential backoff
+// ---------------------------------------------------------------------------
+
+describe("withRetry", () => {
+  it("returns immediately on first-try success without sleeping", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const start = Date.now();
+    const result = await withRetry(fn, { maxRetries: 3, baseDelayMs: 1000 });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it("retries the configured number of times then throws the last error", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("boom"));
+    await expect(
+      withRetry(fn, { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 1 }),
+    ).rejects.toThrow("boom");
+    // maxRetries=2 means 1 initial attempt + 2 retries = 3 calls
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("succeeds on a later attempt and returns that value", async () => {
+    let calls = 0;
+    const fn = vi.fn().mockImplementation(async () => {
+      calls++;
+      if (calls < 3) throw new Error("transient");
+      return "finally";
+    });
+    const result = await withRetry(fn, { maxRetries: 5, baseDelayMs: 1, maxDelayMs: 1 });
+    expect(result).toBe("finally");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("respects maxDelayMs cap on backoff growth", async () => {
+    // Force several failures with a small cap; total should be bounded
+    const fn = vi.fn().mockRejectedValue(new Error("boom"));
+    const start = Date.now();
+    await expect(
+      withRetry(fn, { maxRetries: 3, baseDelayMs: 5, maxDelayMs: 10 }),
+    ).rejects.toThrow();
+    const elapsed = Date.now() - start;
+    // 3 retries at <= 10ms each + scheduling slack — well under 200ms
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it("uses default options when none provided (maxRetries=2)", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("nope"));
+    await expect(withRetry(fn)).rejects.toThrow("nope");
+    // 1 initial + 2 default retries = 3
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the P1 production-ready items and the P2 testing items from `HANDOFF-PLAN.md` (revision 2).

- **P1 #2.2** — CinetPay + Stripe webhook routes (HMAC constant-time, tolerance, idempotent updates)
- **P1 #2.3** — `IntakePayment` Prisma model; `payment.ts` migrated from in-memory `Map` to DB
- **P1 #2.4** — `scripts/test-notoria-lifecycle.ts` headless lifecycle test (PENDING → ACCEPTED → APPLIED + pillar mutation verified on Wakanda demo)
- **P2 #2.5** — 15 unit tests for Monday/Zoho/MCP advertis-inbound (pure mapping, no DB)
- **P2 #2.7** — 17 unit tests for `extractJSON` + `withRetry` in the LLM gateway

Test count: **672 → 704**, `tsc --noEmit` clean.

## Test plan
- [x] `npx prisma db push` applies the new `IntakePayment` table
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx vitest run --exclude tests/integration/**` → 704/704 pass
- [x] `npx tsx scripts/test-notoria-lifecycle.ts` → 3 recos cycled, pillar `a` mutated
- [ ] Configure CinetPay `notify_url` and Stripe webhook endpoint in production providers
- [ ] Smoke-test `/cockpit/brand/notoria` and `/cockpit/brand/jehuty` UI flow in a real browser (sandbox cannot fetch Google Fonts via Turbopack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)