### PR TITLE
feat(anubis): feed-bridge Notoria + Tarsis → cloche notifications (ADR-0031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 ---
 
 
+## v6.1.20 — Portal welcome Console + Agency + product tour interactif (2026-05-03)
+
+**Étend `PortalWelcome` aux 4 portails (ajout Console + Agency) et introduit `PortalTour`, un système de product tour maison (spotlight + tooltip + steps configurables) déclenché en opt-in depuis le modal welcome.** Aucune dépendance npm ajoutée — implémentation custom alignée DS panda + accent rouge fusée + tokens (cf. DESIGN-SYSTEM.md). Pattern : welcome modal au premier accès → CTA "Faire le tour" → spotlight séquentiel des éléments clés (portal switcher, sidebar, command palette, Mestor button).
+
+- `feat(ui)` `src/components/shared/portal-tour.tsx` (NEW) — `PortalTourHost` (composant client, monté au layout) + `startPortalTour(portal)` (déclencheur via custom event `lafusee:tour:start`) + `hasTourSteps(portal)` (helper). Steps configurés par portail (4 Cockpit, 3 Creator, 3 Console, 2 Agency). Spotlight CSS via `box-shadow` + cutout dynamique sur `getBoundingClientRect`. Tooltip auto-positionné top/bottom/left/right avec clamp viewport. A11y : ESC dismiss, ←/→ navigation, role=dialog. Résilient : si target absent du DOM (page sans le selector), step skippé silencieusement. Persistence `localStorage["lafusee:tour:{portal}:v1"]`.
+- `feat(ui)` `src/components/shared/portal-welcome.tsx` — types étendus `PortalKind = "cockpit" | "creator" | "console" | "agency"` + copies dédiées Console (Brand OS opérateur — Gouvernance Mestor / Glory tools / Config) et Agency (Multi-marques / Campagnes coordonnées / Facturation). CTA "Faire le tour" inséré dans footer (conditionné par `hasTourSteps(portal)`), affiché à côté de "Plus tard" + CTA primaire. Le clic ferme le modal et déclenche `startPortalTour` après 250ms (laisse le modal disparaître).
+- `feat(ui)` `src/components/navigation/sidebar.tsx` + `topbar.tsx` — ajout `data-tour-step="sidebar|search|mestor"` sur les targets clés. Selectors uniformes (pas de prefix portal — le scoping vient du fait qu'un portail ne mount qu'un `PortalTourHost`). `[data-portal-switcher]` déjà existant, réutilisé.
+- `feat(ui)` `src/app/(console)/console/layout.tsx` + `(agency)/agency/layout.tsx` — mount `<PortalWelcome />` + `<PortalTourHost />`. Même pattern que Cockpit/Creator depuis v6.1.17.
+- `feat(ui)` `src/app/(cockpit)/cockpit/layout.tsx` + `(creator)/creator/layout.tsx` — ajout `<PortalTourHost />` (mount à côté du `PortalWelcome` déjà présent).
+
+---
+
+
 ## v6.1.19 — SERVICE-MAP : attribution exhaustive des 90 répertoires (2026-05-03)
 
 **Réconciliation arithmétique du SERVICE-MAP : sous-totaux par sous-système (71) ≠ TOTAL (90) — drift d'inventaire pré-existant signalé en commit `10a28ee`. Tous les répertoires `src/server/services/*/` désormais classifiés sans orphelin.** 19 services manquants attribués aux bons sous-systèmes APOGEE après lecture des en-têtes `index.ts` pour validation du governor + tier déclarés in-code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 ---
 
 
+## v6.1.22 — Phase 2.6 manifests closure (89/89 services métier registered) (2026-05-03)
+
+**Phase 2.6 du REFONTE-PLAN refermée : tous les services métier de `src/server/services/` ont désormais un `manifest.ts` co-localisé valide.** Suite résidu signalé en commit `96fc417` (SERVICE-MAP rewrite) qui pointait "~75 manifests à créer" — chiffre lui-même un drift (audit `npm run manifests:audit` au moment du diagnostic montrait 80 manifests registrés sur disk vs filesystem à 84). Triage : seulement **5 manifests réellement manquants** (brand-vault, error-vault, sentinel-handlers, strategy-archive, nsp), 4 manifests existants stale dans le registry (anubis, imhotep, ptah, source-classifier) régénérés.
+
+- `chore(governance)` `src/server/services/brand-vault/manifest.ts` (NEW) — gov MESTOR, 6 capabilities (createBrandAsset, createCandidateBatch, selectFromBatch, promoteToActive, supersede, archive). missionContribution DIRECT_BOTH, missionStep 3. Phase 10 ADR-0012.
+- `chore(governance)` `src/server/services/error-vault/manifest.ts` (NEW) — gov SESHAT, 5 capabilities (capture, captureError, markResolved, batchMarkResolved, getStats). missionContribution GROUND_INFRASTRUCTURE avec groundJustification (sans collecteur runtime, bugs Ptah/NSP/cron passent silencieusement). Phase 11 ADR-0013.
+- `chore(governance)` `src/server/services/sentinel-handlers/manifest.ts` (NEW) — gov MESTOR, 1 capability (processPendingSentinels). missionContribution DIRECT_BOTH (Loi 4 maintien orbite ICONE), missionStep 5. Phase 9-suite.
+- `chore(governance)` `src/server/services/strategy-archive/manifest.ts` (NEW) — gov MESTOR, 4 capabilities (archiveStrategyHandler, restoreStrategyHandler, purgeArchivedStrategyHandler, listArchivedStrategies). acceptsIntents = [OPERATOR_ARCHIVE_STRATEGY, OPERATOR_RESTORE_STRATEGY, OPERATOR_PURGE_ARCHIVED_STRATEGY]. ADR-0028.
+- `chore(governance)` `src/server/services/nsp/manifest.ts` (NEW stub) — gov INFRASTRUCTURE, 1 capability (publish). Stub minimal pour permettre aux services métier (anubis) de déclarer `nsp` en dependencies sans casser l'audit registry. ADR-0025/0026.
+- `chore(governance)` `src/server/governance/__generated__/manifest-imports.ts` régénéré via `npm run manifests:gen` — passe de **80 → 89 manifests** registrés (+5 nouveaux + 4 stale anubis/imhotep/ptah/source-classifier). Audit `npm run manifests:audit` clean (seul `utils/` reste sans manifest, helper hors classification APOGEE par design).
+- `docs(governance)` `docs/governance/SERVICE-MAP.md` — toutes les 86 occurrences "à créer" colonne Manifest remplacées par "✅ existant" (replace_all). Footnote `nsp/` mise à jour : "n/a (utilitaire pur)" → "✅ existant (stub utilitaire)". Section Verdict §9 réécrite : "~75 manifests à créer" → "Phase 2.6 ✅ COMPLETÉ : 89/89 services métier + 1 stub utilitaire".
+- `chore(version)` `package.json` + `package-lock.json` + `marketing-footer.tsx` re-sync `6.1.19` → `6.1.22` après ADR-0030 commit `a1ac5f9` (CHANGELOG bumpé v6.1.21 sans propagation surfaces).
+
+Verify : `npm run manifests:audit` → `Manifests registered: 89, ✓ clean`. `npx tsx scripts/audit-mission-drift.ts` → `scanned 89 manifests, 417 capabilities, ✓ no drift detected`. Typecheck `npx tsc --noEmit` → 0 erreur introduite. Zod 4 syntax `z.record(z.string(), z.unknown())` adopté (Zod 3 syntax `z.record(z.unknown())` rejetée par compiler).
+
+Cap APOGEE 7/7 Neteru actifs maintenu. Aucun nouveau Neter, aucun nouveau model Prisma, aucune nouvelle entité métier — pure documentation/contrat de services existants.
+
+---
+
+
 ## v6.1.21 — ADR-0030 proposed : intake closure ADVE 100% + gate actualizeRT (2026-05-03)
 
 **Refonte du tunnel intake → cascade ADVE → R+T : ADR proposed pour fermer l'écart `derivable: false` du contrat INTAKE et gater `actualizeRT` sur `RTIS_CASCADE`.** Diagnostic NEFER session 2026-05-03 PM : sur cockpit pilier, "Suffisant" et "Complet" plafonnent à ~80% sans monter à 100%. Cause racine : (1) intake question-bank ne couvre pas les 5+ champs `needsHuman` du contrat INTAKE (`A.noyauIdentitaire`, `A.citationFondatrice`, `D.positionnement`, `D.promesseMaitre`, `D.personas`, `V.produitsCatalogue`), (2) AI extraction conservatrice par design (anti-hallucination), (3) `auto-filler` ignore silencieusement les `needsHuman` sans les remonter à l'UI, (4) `actualizeRT` n'a pas de gate `RTIS_CASCADE` (incohérent avec `generateBatch` qui l'a). Conséquence : la cascade ADVERTIS part toujours de matière sparse → R+T mediocres → stepper Notoria bloqué → opérateur en aveugle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 ---
 
 
+## v6.1.21 — ADR-0030 proposed : intake closure ADVE 100% + gate actualizeRT (2026-05-03)
+
+**Refonte du tunnel intake → cascade ADVE → R+T : ADR proposed pour fermer l'écart `derivable: false` du contrat INTAKE et gater `actualizeRT` sur `RTIS_CASCADE`.** Diagnostic NEFER session 2026-05-03 PM : sur cockpit pilier, "Suffisant" et "Complet" plafonnent à ~80% sans monter à 100%. Cause racine : (1) intake question-bank ne couvre pas les 5+ champs `needsHuman` du contrat INTAKE (`A.noyauIdentitaire`, `A.citationFondatrice`, `D.positionnement`, `D.promesseMaitre`, `D.personas`, `V.produitsCatalogue`), (2) AI extraction conservatrice par design (anti-hallucination), (3) `auto-filler` ignore silencieusement les `needsHuman` sans les remonter à l'UI, (4) `actualizeRT` n'a pas de gate `RTIS_CASCADE` (incohérent avec `generateBatch` qui l'a). Conséquence : la cascade ADVERTIS part toujours de matière sparse → R+T mediocres → stepper Notoria bloqué → opérateur en aveugle.
+
+- `docs(governance)` `docs/governance/adr/0030-intake-closure-adve-100pct.md` (NEW) — ADR proposed avec 3 axes coordonnés séquencés : Axe 1 = panneau UX `needsHuman` sur `pillar-page.tsx` (résout asymétrie d'info, ~150 lignes), Axe 3 = `preconditions: ["RTIS_CASCADE"]` sur `actualizeRT` + stepper Notoria 5-étapes (anti-drift LOI 1, ~30 lignes), Axe 2 = closure intake question-bank avec 6 nouvelles questions + `audit-intake-coverage.ts` CI gate (refonte produit, ~300 lignes). Décisions explicitement rejetées : "tout `derivable: true` AI" (casse anti-hallucination), "100% obligatoire à l'intake" (friction landing), "supprimer `derivable: false`" (distinction utile pour le moteur). Plan 3 PRs séparées avec compatibilité existant + tests d'invariant + runbook strategies pré-existantes. Précédé par v6.1.18 (`rtis-cascade.savePillar` cache reconciliation, fix indispensable préalable).
+
+---
+
+
 ## v6.1.20 — Portal welcome Console + Agency + product tour interactif (2026-05-03)
 
 **Étend `PortalWelcome` aux 4 portails (ajout Console + Agency) et introduit `PortalTour`, un système de product tour maison (spotlight + tooltip + steps configurables) déclenché en opt-in depuis le modal welcome.** Aucune dépendance npm ajoutée — implémentation custom alignée DS panda + accent rouge fusée + tokens (cf. DESIGN-SYSTEM.md). Pattern : welcome modal au premier accès → CTA "Faire le tour" → spotlight séquentiel des éléments clés (portal switcher, sidebar, command palette, Mestor button).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 ---
 
 
+## v6.1.19 — SERVICE-MAP : attribution exhaustive des 90 répertoires (2026-05-03)
+
+**Réconciliation arithmétique du SERVICE-MAP : sous-totaux par sous-système (71) ≠ TOTAL (90) — drift d'inventaire pré-existant signalé en commit `10a28ee`. Tous les répertoires `src/server/services/*/` désormais classifiés sans orphelin.** 19 services manquants attribués aux bons sous-systèmes APOGEE après lecture des en-têtes `index.ts` pour validation du governor + tier déclarés in-code.
+
+- `docs(governance)` `docs/governance/SERVICE-MAP.md` — réécriture intégrale avec attribution exhaustive. Counts par section : Propulsion 14 (briefs 13 + forge `ptah/` 1), Guidance 12, Telemetry 21, Sustainment 12, Operations 10, Crew Programs 6, **Comms 3 (NEW section)**, Admin 11. Total : **89 services métier classifiés + 1 helper (`utils/`) = 90 répertoires**. Vérification arithmétique : `14+12+21+12+10+6+3+11 = 89`.
+- `docs(governance)` 19 services orphelins attribués : `ptah/` (Propulsion forge §1 ligne explicite), `founder-psychology/` (Crew Programs §6, gov INFRASTRUCTURE per index.ts), `imhotep/` (Crew Programs §6 orchestrateur), `playbook-capitalization/` + `sector-intelligence/` + `source-classifier/` + `error-vault/` (Telemetry §3, gov SESHAT), `brand-vault/` + `model-policy/` + `sentinel-handlers/` + `strategy-archive/` + `nsp/` (Sustainment §4), `monetization/` + `payment-providers/` (Operations §5), `email/` + `oauth-integrations/` + `anubis/` (**Comms §7 NEW**), `mfa/` + `collab-doc/` (Admin §8).
+- `docs(governance)` section §7 **Comms** créée (était absente — drift structurel pré-existant). 2 satellites + `anubis/` orchestrateur. Provider façades (`meta-ads/google-ads/x-ads/tiktok-ads/mailgun/twilio`) co-localisées dans `anubis/providers/` — pas comptées comme services distincts.
+- `docs(governance)` `pillar-readiness/` (vit dans `src/server/governance/`, pas `src/server/services/`) sorti du compte Guidance — passé à 12 services. Footnote ajoutée pour traçabilité.
+- `docs(governance)` §10 Services manquants nettoyée : `messaging/` retiré (couvert par `nsp/` + `anubis/`), `nsp/` retiré (existe maintenant). Restent 3 services optionnels (`compensating-intents/`, `cost-gate/`, `notification/`) — non bloquants pour complétude APOGEE.
+- `chore(version)` `package-lock.json` re-sync `6.1.16` → `6.1.18` après bump manuel user `package.json` v6.1.18 (commit `602e050`).
+
+---
+
+
 ## v6.1.18 — fix(rtis-cascade) — completionLevel cache reconciliation (2026-05-03)
 
 **Le stepper Notoria restait figé sur étape 1 (R+T) après "Lancer la veille R+T" + apply, parce que `actualizePillar()` écrivait `Pillar.content` sans reconcilier le cache `Pillar.completionLevel`.** Drift LOI 1 (point unique de mutation) : `rtis-cascade.savePillar` était le seul caller du gateway dans `src/server/services/mestor/` à utiliser `writePillar` au lieu de `writePillarAndScore` (les 5 autres callers — `operator-amend`, `hyperviseur` ×4 — utilisaient déjà la forme canonique). Résultat : `Pillar.content` mis à jour avec la veille fraîche, `assessPillar` retournait `stage === COMPLETE`, mais `completionLevel` cache restait à `INCOMPLET` (valeur posée à l'intake) → `dashboard.completionLevels.r/t === "INCOMPLET"` → stepper bloqué.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 ---
 
 
+## v6.1.23 — ADR-0031 : feed-bridge Notoria + Tarsis → cloche notifications (2026-05-03)
+
+**Phase 16 ferme la boucle qui était ouverte depuis ADR-0025 : la stack notification temps-réel est enfin alimentée par les producteurs de Signal métier.** Diagnostic NEFER session 2026-05-03 : `grep "anubis.pushNotification" src/` retournait un seul hit (notification.testPush admin), donc le bell topbar était techniquement fonctionnel mais inerte en prod — Notoria écrivait des `Signal NOTORIA_BATCH_READY`, Tarsis écrivait des `Signal WEAK_SIGNAL_ALERT`, mais aucune `Notification` row n'était créée pour le founder. Cause : feature Phase 16 shippée, consumers absents.
+
+- `feat(anubis)` `src/server/services/anubis/feed-bridge.ts` (NEW) — helper `notifyOnFeedSignal({ signalId, signalType, strategyId, title, body, link?, priority? })` qui filtre par whitelist `FEED_SIGNAL_TYPES` (8 types : WEAK_SIGNAL_ALERT, MARKET_SIGNAL, NOTORIA_BATCH_READY, STRONG, WEAK, METRIC, SCORE_IMPROVEMENT, SCORE_DECLINE), mappe priorité automatique par type, résout les destinataires depuis `Strategy.userId` (founder owner — MVP), et push via `anubis.pushNotification()` (qui gère lui-même quiet hours + NSP publish + Web Push). Failure mode non-bloquant : la création du Signal upstream ne casse jamais à cause d'un bug notification.
+- `feat(notoria)` `src/server/services/notoria/engine.ts` — après `db.signal.create({ type: "NOTORIA_BATCH_READY" })`, appel `notifyOnFeedSignal()` avec link `/cockpit/notoria?batch=<id>`. Le founder voit maintenant la cloche s'allumer dès qu'un batch Notoria est prêt.
+- `feat(seshat)` `src/server/services/seshat/tarsis/weak-signal-analyzer.ts` — après `db.signal.create({ type: "WEAK_SIGNAL_ALERT" })` (urgency HIGH/CRITICAL only), notification cross-brand : `notifyOnFeedSignal()` est appelé pour `[strategyId, ...affectedStrategyIds]` — un weak signal qui affecte 5 brands déclenche 5 notifs (founder de chaque brand affectée), priorité escaladée à `CRITICAL` si urgency = CRITICAL.
+- `chore(anubis)` `src/server/services/anubis/index.ts` — re-export `notifyOnFeedSignal` + types `NotifyOnFeedSignalArgs` / `NotifyOnFeedSignalResult` pour consommation depuis services métier.
+- `docs(governance)` `docs/governance/adr/0031-notification-feed-bridge.md` (NEW) — décisions rejetées explicitement documentées : pas de hook router Jehuty (lecture pure, mauvais point d'entrée), pas d'Intent `ANUBIS_PUSH_NOTIFICATION` via Mestor (overhead governance pour side-effect informatif), pas de notification UPgraders Console MVP (reporté). Étapes futures : Membership lookup pour UPgraders, digest cadencé si bruit, branchement market-intelligence signal-collector.
+
+Verify : `npx tsc --noEmit` → 0 erreur introduite (6 erreurs résiduelles pré-existantes dans `.next/types/validator.ts` sur pages oracle, RESIDUAL-DEBT). `npx tsx scripts/audit-neteru-narrative.ts` → 0 finding. `npx tsx scripts/audit-pantheon-completeness.ts` → 7/7 Neteru OK. `npx tsx scripts/audit-governance.ts` → 0 error / 217 warn (toutes pré-existantes, aucune liée à feed-bridge).
+
+Résidus : vitest cassé sur `node_modules/vitest/node_modules/std-env` manquant — pré-existant, à traquer dans RESIDUAL-DEBT (impact : tests anti-drift CI non-runnables localement). Pas de modif Prisma, pas de nouveau Neter, pas de nouvelle Capability (consommation façade locale `pushNotification` existante). Cap APOGEE 7/7 maintenu.
+
+---
+
+
 ## v6.1.22 — Phase 2.6 manifests closure (89/89 services métier registered) (2026-05-03)
 
 **Phase 2.6 du REFONTE-PLAN refermée : tous les services métier de `src/server/services/` ont désormais un `manifest.ts` co-localisé valide.** Suite résidu signalé en commit `96fc417` (SERVICE-MAP rewrite) qui pointait "~75 manifests à créer" — chiffre lui-même un drift (audit `npm run manifests:audit` au moment du diagnostic montrait 80 manifests registrés sur disk vs filesystem à 84). Triage : seulement **5 manifests réellement manquants** (brand-vault, error-vault, sentinel-handlers, strategy-archive, nsp), 4 manifests existants stale dans le registry (anubis, imhotep, ptah, source-classifier) régénérés.

--- a/docs/governance/RESIDUAL-DEBT.md
+++ b/docs/governance/RESIDUAL-DEBT.md
@@ -1,6 +1,24 @@
 # RESIDUAL DEBT — inventaire honnête des résidus
 
-État au commit `eee156d` + vague de fermeture **2026-04-29 PM** + audit pré-deploy **2026-05-02** (NEFER) + post-merge Phase 16 **2026-05-02 PM** (PR #40) + fix v6.1.18 cache reconciliation **2026-05-03 PM** (NEFER).
+État au commit `eee156d` + vague de fermeture **2026-04-29 PM** + audit pré-deploy **2026-05-02** (NEFER) + post-merge Phase 16 **2026-05-02 PM** (PR #40) + fix v6.1.18 cache reconciliation **2026-05-03 PM** (NEFER) + ship feed-bridge ADR-0031 **2026-05-03** (PR #50).
+
+---
+
+## v6.1.23 — résidus post-ship feed-bridge ADR-0031 (2026-05-03)
+
+### Vitest cassé localement — `std-env` introuvable
+
+`npx vitest run <any-test>` échoue avec `Cannot find package '<root>/node_modules/vitest/node_modules/std-env/index.js' imported from <root>/node_modules/vitest/dist/cli.js`. Le sous-package `std-env` est attendu en CJS (`std-env/dist/index.cjs`) mais résolu en ESM par Node 22.14. Bloque l'exécution locale de tous les tests vitest, y compris **les tests anti-drift CI** : `tests/unit/governance/neteru-coherence.test.ts`, `tests/unit/governance/manipulation-coherence.test.ts`, `tests/unit/governance/design-tokens-cascade.test.ts`, `tests/unit/services/glory-tools.test.ts`.
+
+Conséquence opérationnelle : NEFER Phase 5 vérification se rabat sur les `audit-*.ts` scripts (`audit-neteru-narrative`, `audit-pantheon-completeness`, `audit-governance`) qui passent en `tsx` direct, mais ne couvre pas les invariants vérifiés uniquement par les tests vitest. Si la CI GitHub Actions tourne sur une autre version Node ou réinstalle propre, elle peut passer — la dette est sur l'environnement local du contributeur.
+
+Fix candidats à essayer dans cet ordre (du moins invasif au plus) :
+1. `rm -rf node_modules package-lock.json && npm install` — réhydratation propre, peut fixer une corruption de hoisting npm
+2. Bump `vitest` `^4.1.5` → dernier patch/minor compatible (vérifier breaking changes Vitest 4 → 5 si latest > 4.x)
+3. Forcer `std-env` au top-level deps en override : `"overrides": { "std-env": "^3.x.x" }` dans `package.json`
+4. Si Node version mismatch : checker `.nvmrc` / `engines.node` dans `package.json` et aligner Node local
+
+Détecté dans la session ship feed-bridge ADR-0031 — non bloquant pour le ship lui-même (audits TS+governance passent), mais bloque toute itération test-driven.
 
 ---
 

--- a/docs/governance/SERVICE-MAP.md
+++ b/docs/governance/SERVICE-MAP.md
@@ -6,7 +6,7 @@
 
 Source de vérité : `find src/server/services -mindepth 1 -maxdepth 1 -type d`. Mis à jour avec [APOGEE.md](APOGEE.md) §4 + [PANTHEON.md](PANTHEON.md).
 
-Phase 2 du REFONTE-PLAN exige un `manifest.ts` co-localisé pour chaque service métier — la colonne **Manifest** indique l'état attendu (à créer ou existant).
+Phase 2.6 du REFONTE-PLAN exige un `manifest.ts` co-localisé pour chaque service métier — **objectif atteint**. La colonne **Manifest** ci-dessous indique l'état observé : `✅ existant` pour les 89 services métier + `nsp/` (stub utilitaire). Audit `npm run manifests:audit` clean.
 
 ---
 
@@ -100,19 +100,19 @@ Génèrent la poussée vers l'apogée. **13 services briefs (ARTEMIS) + 1 servic
 
 | Service | Rôle propulsion | Governor | Manifest |
 |---|---|---|---|
-| `artemis/` | Thrust controller — exécute Glory tools, séquences GLORY | ARTEMIS | à créer |
-| `glory-tools/` | Catalogue + métadonnées des 56 thrusters (40 legacy + 9 P13 + 4 P14 + 3 P15) | ARTEMIS | à créer |
-| `sequence-vault/` | Bibliothèque des 57 séquences GLORY (skill tree, post Phase 13 ORACLE_*) | ARTEMIS | à créer |
-| `pipeline-orchestrator/` | Orchestration topo-triée des séquences | ARTEMIS | à créer |
-| `notoria/` | Pipeline production des livrables | ARTEMIS | à créer |
-| `driver-engine/` | Drivers d'engagement (E pillar tactics) | ARTEMIS | à créer |
-| `campaign-manager/` | Gestion campagnes en vol | ARTEMIS | à créer |
-| `campaign-plan-generator/` | Génération plans de campagne | ARTEMIS | à créer |
-| `mission-templates/` | Templates de missions standard | ARTEMIS | à créer |
-| `implementation-generator/` | Génération plans d'implémentation | ARTEMIS | à créer |
-| `guidelines-renderer/` | Rendu brand guidelines (livrable) | ARTEMIS | à créer |
-| `value-report-generator/` | Rendu rapport valeur (livrable client) | ARTEMIS | à créer |
-| `seshat-bridge/` | **Bridge** Telemetry → Propulsion (signaux qui déclenchent missions) | ARTEMIS | à créer |
+| `artemis/` | Thrust controller — exécute Glory tools, séquences GLORY | ARTEMIS | ✅ existant |
+| `glory-tools/` | Catalogue + métadonnées des 56 thrusters (40 legacy + 9 P13 + 4 P14 + 3 P15) | ARTEMIS | ✅ existant |
+| `sequence-vault/` | Bibliothèque des 57 séquences GLORY (skill tree, post Phase 13 ORACLE_*) | ARTEMIS | ✅ existant |
+| `pipeline-orchestrator/` | Orchestration topo-triée des séquences | ARTEMIS | ✅ existant |
+| `notoria/` | Pipeline production des livrables | ARTEMIS | ✅ existant |
+| `driver-engine/` | Drivers d'engagement (E pillar tactics) | ARTEMIS | ✅ existant |
+| `campaign-manager/` | Gestion campagnes en vol | ARTEMIS | ✅ existant |
+| `campaign-plan-generator/` | Génération plans de campagne | ARTEMIS | ✅ existant |
+| `mission-templates/` | Templates de missions standard | ARTEMIS | ✅ existant |
+| `implementation-generator/` | Génération plans d'implémentation | ARTEMIS | ✅ existant |
+| `guidelines-renderer/` | Rendu brand guidelines (livrable) | ARTEMIS | ✅ existant |
+| `value-report-generator/` | Rendu rapport valeur (livrable client) | ARTEMIS | ✅ existant |
+| `seshat-bridge/` | **Bridge** Telemetry → Propulsion (signaux qui déclenchent missions) | ARTEMIS | ✅ existant |
 | `ptah/` | **Forge orchestrator** — matérialise les briefs en assets (image/video/audio/icon/refine/...) | **PTAH** (ADR-0009) | ✅ existant |
 
 ---
@@ -124,17 +124,17 @@ Dirigent la trajectoire. Décisions, validations, plans.
 | Service | Rôle guidance | Governor | Manifest |
 |---|---|---|---|
 | `mestor/` | Computer de guidage central — Intent dispatcher (`emitIntent`) | MESTOR | partiel (`intents.ts:179`) |
-| `pillar-gateway/` | Écriture gouvernée des Pillars (`writePillarAndScore`) | MESTOR | à créer |
-| `pillar-maturity/` | Évaluation maturity N0-N6 + assessor | MESTOR | à créer |
-| `pillar-versioning/` | Versionning des contrats Pillar | MESTOR | à créer |
-| `pillar-normalizer/` | Normalisation inputs avant write | MESTOR | à créer |
-| `rtis-protocols/` | Protocoles cascade R-T-I-S | MESTOR | à créer |
-| `diagnostic-engine/` | Moteur de diagnostic substantiel | MESTOR | à créer |
-| `cross-validator/` | Validation cross-pillar cohérence | MESTOR | à créer |
-| `vault-enrichment/` | Enrichissement strategy depuis vault | MESTOR | à créer |
-| `strategy-presentation/` | Assemblage Oracle 21 sections + catalogue `OracleError` (ADR-0022) | MESTOR | à créer |
-| `prompt-registry/` | Registre prompts LLM versionnés | MESTOR | à créer |
-| `staleness-propagator/` | Détecte et propage staleness | MESTOR | à créer |
+| `pillar-gateway/` | Écriture gouvernée des Pillars (`writePillarAndScore`) | MESTOR | ✅ existant |
+| `pillar-maturity/` | Évaluation maturity N0-N6 + assessor | MESTOR | ✅ existant |
+| `pillar-versioning/` | Versionning des contrats Pillar | MESTOR | ✅ existant |
+| `pillar-normalizer/` | Normalisation inputs avant write | MESTOR | ✅ existant |
+| `rtis-protocols/` | Protocoles cascade R-T-I-S | MESTOR | ✅ existant |
+| `diagnostic-engine/` | Moteur de diagnostic substantiel | MESTOR | ✅ existant |
+| `cross-validator/` | Validation cross-pillar cohérence | MESTOR | ✅ existant |
+| `vault-enrichment/` | Enrichissement strategy depuis vault | MESTOR | ✅ existant |
+| `strategy-presentation/` | Assemblage Oracle 21 sections + catalogue `OracleError` (ADR-0022) | MESTOR | ✅ existant |
+| `prompt-registry/` | Registre prompts LLM versionnés | MESTOR | ✅ existant |
+| `staleness-propagator/` | Détecte et propage staleness | MESTOR | ✅ existant |
 
 > Helpers TS dans `strategy-presentation/` (n/a manifest, n/a count) :
 > - `error-codes.ts` — catalogue typé `ORACLE-NNN` + classe `OracleError` + `toOracleError` (ADR-0022)
@@ -151,25 +151,25 @@ Observent, mesurent, archivent.
 | Service | Rôle telemetry | Governor | Manifest |
 |---|---|---|---|
 | `seshat/` | Telemetry processor central + Tarsis sensors + ranker | SESHAT | partiel |
-| `jehuty/` | Cross-brand intelligence feed (V5.4) | SESHAT | à créer |
-| `knowledge-aggregator/` | Agrégation knowledge graph | SESHAT | à créer |
-| `knowledge-capture/` | Capture nouveaux knowledge entries | SESHAT | à créer |
-| `knowledge-seeder/` | Seeding knowledge initial | SESHAT | à créer |
-| `market-intelligence/` | Intel sectorielle | SESHAT | à créer |
+| `jehuty/` | Cross-brand intelligence feed (V5.4) | SESHAT | ✅ existant |
+| `knowledge-aggregator/` | Agrégation knowledge graph | SESHAT | ✅ existant |
+| `knowledge-capture/` | Capture nouveaux knowledge entries | SESHAT | ✅ existant |
+| `knowledge-seeder/` | Seeding knowledge initial | SESHAT | ✅ existant |
+| `market-intelligence/` | Intel sectorielle | SESHAT | ✅ existant |
 | `sector-intelligence/` | Sector as first-class entity (APOGEE drift 5.2 fix) | SESHAT | ✅ existant |
-| `source-classifier/` | Reads BrandDataSource → BrandAsset DRAFTs (taxonomie canonique) | SESHAT | à créer |
+| `source-classifier/` | Reads BrandDataSource → BrandAsset DRAFTs (taxonomie canonique) | SESHAT | ✅ existant |
 | `playbook-capitalization/` | Cross-brand learning loop (MISSION drift 5.10) | SESHAT | ✅ existant |
-| `audit-trail/` | Trail audit transverse | INFRASTRUCTURE | à créer |
-| `ecosystem-engine/` | Moteur métriques cross-tenant | SESHAT | à créer |
-| `ai-cost-tracker/` | Tracking coûts LLM par intent | THOT | à créer |
-| `cult-index-engine/` | Cult index (mass measurement propellant) | SESHAT | à créer |
-| `devotion-engine/` | Devotion ladder calculation | SESHAT | à créer |
-| `tier-evaluator/` | Classification ZOMBIE→ICONE | SESHAT | à créer |
-| `advertis-scorer/` | Calcul score composite ADVERTIS | SESHAT | à créer |
-| `advertis-connectors/` | Connecteurs sources signaux (social, presse) | SESHAT | à créer |
-| `feedback-loop/` | Boucle feedback Mestor ↔ Seshat | SESHAT | à créer |
-| `feedback-processor/` | Traitement feedbacks structurés | SESHAT | à créer |
-| `asset-tagger/` | Tagging automatique assets | SESHAT | à créer |
+| `audit-trail/` | Trail audit transverse | INFRASTRUCTURE | ✅ existant |
+| `ecosystem-engine/` | Moteur métriques cross-tenant | SESHAT | ✅ existant |
+| `ai-cost-tracker/` | Tracking coûts LLM par intent | THOT | ✅ existant |
+| `cult-index-engine/` | Cult index (mass measurement propellant) | SESHAT | ✅ existant |
+| `devotion-engine/` | Devotion ladder calculation | SESHAT | ✅ existant |
+| `tier-evaluator/` | Classification ZOMBIE→ICONE | SESHAT | ✅ existant |
+| `advertis-scorer/` | Calcul score composite ADVERTIS | SESHAT | ✅ existant |
+| `advertis-connectors/` | Connecteurs sources signaux (social, presse) | SESHAT | ✅ existant |
+| `feedback-loop/` | Boucle feedback Mestor ↔ Seshat | SESHAT | ✅ existant |
+| `feedback-processor/` | Traitement feedbacks structurés | SESHAT | ✅ existant |
+| `asset-tagger/` | Tagging automatique assets | SESHAT | ✅ existant |
 | `error-vault/` | Collecteur erreurs runtime (server/client/Prisma/NSP/Ptah/cron/webhook) — Phase 11 | SESHAT | ✅ existant |
 
 ---
@@ -180,18 +180,18 @@ Maintiennent la mission viable techniquement. Mémoires long terme, transports, 
 
 | Service | Rôle sustainment | Governor | Manifest |
 |---|---|---|---|
-| `llm-gateway/` | Engine controller multi-provider (v4) | INFRASTRUCTURE | à créer |
-| `model-policy/` | Résolution gouvernée `purpose → model` (cache + Prisma `ModelPolicy`) | INFRASTRUCTURE | à créer |
-| `financial-brain/` | **Thot** — fuel manager, capacity tracking | THOT | à créer |
-| `budget-allocator/` | Allocation budget par mission | THOT | à créer |
-| `approval-workflow/` | Workflow d'approbation pré-action | MESTOR | à créer |
-| `sla-tracker/` | SLO/SLA tracking par Intent kind | INFRASTRUCTURE | à créer |
-| `operator-isolation/` | Tenant isolation (default-deny) | INFRASTRUCTURE | à créer |
+| `llm-gateway/` | Engine controller multi-provider (v4) | INFRASTRUCTURE | ✅ existant |
+| `model-policy/` | Résolution gouvernée `purpose → model` (cache + Prisma `ModelPolicy`) | INFRASTRUCTURE | ✅ existant |
+| `financial-brain/` | **Thot** — fuel manager, capacity tracking | THOT | ✅ existant |
+| `budget-allocator/` | Allocation budget par mission | THOT | ✅ existant |
+| `approval-workflow/` | Workflow d'approbation pré-action | MESTOR | ✅ existant |
+| `sla-tracker/` | SLO/SLA tracking par Intent kind | INFRASTRUCTURE | ✅ existant |
+| `operator-isolation/` | Tenant isolation (default-deny) | INFRASTRUCTURE | ✅ existant |
 | `neteru-shared/` | Governance registry central | INFRASTRUCTURE | manifests des autres |
 | `brand-vault/` | BrandAsset CRUD engine — vault unifié (ADR-0012, Phase 10) | MESTOR | ✅ existant |
-| `strategy-archive/` | 2-phase soft archive + hard purge (`Strategy.archivedAt`) | INFRASTRUCTURE | à créer |
+| `strategy-archive/` | 2-phase soft archive + hard purge (`Strategy.archivedAt`) | INFRASTRUCTURE | ✅ existant |
 | `sentinel-handlers/` | Handlers cron `/api/cron/sentinels` — consomme IntentEmission PENDING (Loi 4 maintien orbite) | MESTOR | ✅ existant |
-| `nsp/` | Neteru Streaming Protocol — transport publish/subscribe vers UI | INFRASTRUCTURE | n/a (utilitaire pur) |
+| `nsp/` | Neteru Streaming Protocol — transport publish/subscribe vers UI | INFRASTRUCTURE | ✅ existant (stub utilitaire) |
 
 > `cross-validator/` est compté en Guidance (rôle dominant : validation cross-pillar). Ses invariants techniques sont consommés par Sustainment — pas de double-count.
 
@@ -203,16 +203,16 @@ Argent, contrats, facturation, monétisation. Sans Operations, pas de business.
 
 | Service | Rôle operations | Governor | Manifest |
 |---|---|---|---|
-| `commission-engine/` | Calcul commissions UPgraders/agence/creator | THOT | à créer |
-| `financial-engine/` | Logique business financière | THOT | à créer |
-| `financial-reconciliation/` | Réconciliation transactions | THOT | à créer |
-| `mobile-money/` | Intégration paiement mobile (Orange/MTN/Wave) | INFRASTRUCTURE | à créer |
-| `payment-providers/` | Registry abstrait providers paiement (`pickProvider()`) | INFRASTRUCTURE | à créer |
+| `commission-engine/` | Calcul commissions UPgraders/agence/creator | THOT | ✅ existant |
+| `financial-engine/` | Logique business financière | THOT | ✅ existant |
+| `financial-reconciliation/` | Réconciliation transactions | THOT | ✅ existant |
+| `mobile-money/` | Intégration paiement mobile (Orange/MTN/Wave) | INFRASTRUCTURE | ✅ existant |
+| `payment-providers/` | Registry abstrait providers paiement (`pickProvider()`) | INFRASTRUCTURE | ✅ existant |
 | `monetization/` | Pricing localisé marché (FMCG / SaaS / agence — Mission contribution: GROUND_INFRASTRUCTURE) | THOT | ✅ existant |
-| `crm-engine/` | Relation client structurée | INFRASTRUCTURE | à créer |
-| `upsell-detector/` | Signaux d'upgrade contractuel | SESHAT | à créer |
-| `campaign-budget-engine/` | Budgets par campagne | THOT | à créer |
-| `data-export/` | Export données structurées (factures, reports) | INFRASTRUCTURE | à créer |
+| `crm-engine/` | Relation client structurée | INFRASTRUCTURE | ✅ existant |
+| `upsell-detector/` | Signaux d'upgrade contractuel | SESHAT | ✅ existant |
+| `campaign-budget-engine/` | Budgets par campagne | THOT | ✅ existant |
+| `data-export/` | Export données structurées (factures, reports) | INFRASTRUCTURE | ✅ existant |
 
 ---
 
@@ -223,10 +223,10 @@ Talent, formation, matching, QC, psychologie founder. **5 satellites + `imhotep/
 | Service | Rôle crew programs | Governor | Manifest |
 |---|---|---|---|
 | `imhotep/` | **Orchestrateur** — wrappe matching/talent/team/tier/qc, formation Académie (Phase 14, ADR-0019) | **IMHOTEP** | ✅ existant |
-| `talent-engine/` | Évaluation, scoring, ranking creators | INFRASTRUCTURE | à créer |
-| `matching-engine/` | Match creator ↔ mission | INFRASTRUCTURE | à créer |
-| `team-allocator/` | Composition d'équipes optimales | INFRASTRUCTURE | à créer |
-| `qc-router/` | Routing quality control | INFRASTRUCTURE | à créer |
+| `talent-engine/` | Évaluation, scoring, ranking creators | INFRASTRUCTURE | ✅ existant |
+| `matching-engine/` | Match creator ↔ mission | INFRASTRUCTURE | ✅ existant |
+| `team-allocator/` | Composition d'équipes optimales | INFRASTRUCTURE | ✅ existant |
+| `qc-router/` | Routing quality control | INFRASTRUCTURE | ✅ existant |
 | `founder-psychology/` | Mécanise "founder = first superfan" (MISSION drift 5.9) | INFRASTRUCTURE | ✅ existant |
 
 ---
@@ -238,8 +238,8 @@ Channels externes vers audience. Ad networks, email, SMS, OAuth flows. **2 satel
 | Service | Rôle comms | Governor | Manifest |
 |---|---|---|---|
 | `anubis/` | **Orchestrateur** — broadcast multi-canal, ad networks, Credentials Vault (Phase 15, ADR-0020 + ADR-0021) | **ANUBIS** | ✅ existant |
-| `email/` | Email transactionnel (Resend / SendGrid / SES + dev fallback console) | ANUBIS | à créer |
-| `oauth-integrations/` | OAuth 2.0 Authorization Code flow pour intégrations sortantes (Google, LinkedIn, Meta) | ANUBIS | à créer |
+| `email/` | Email transactionnel (Resend / SendGrid / SES + dev fallback console) | ANUBIS | ✅ existant |
+| `oauth-integrations/` | OAuth 2.0 Authorization Code flow pour intégrations sortantes (Google, LinkedIn, Meta) | ANUBIS | ✅ existant |
 
 > Provider façades (Meta Ads, Google Ads, X Ads, TikTok Ads, Mailgun, Twilio) sont co-localisées dans `anubis/providers/` — pas comptées comme services distincts (sub-modules de l'orchestrateur).
 
@@ -251,15 +251,15 @@ Configuration, boot, ingestion système, support, security, collaboration intern
 
 | Service | Rôle admin | Governor | Manifest |
 |---|---|---|---|
-| `boot-sequence/` | Initialisation système au démarrage | INFRASTRUCTURE | à créer |
-| `process-scheduler/` | Cron + queue intents async | INFRASTRUCTURE | à créer |
-| `ingestion-pipeline/` | Pipeline d'ingestion data externe | INFRASTRUCTURE | à créer |
-| `quick-intake/` | Pipeline onboarding intake (rev 9) | INFRASTRUCTURE | à créer |
-| `brief-ingest/` | Ingestion PDF briefs | MESTOR | à créer |
-| `demo-data/` | Seeding pour staging/demo | INFRASTRUCTURE | à créer |
-| `country-registry/` | Référentiel pays (devises, langues) | INFRASTRUCTURE | à créer |
-| `translation/` | i18n service (P7) | INFRASTRUCTURE | à créer |
-| `board-export/` | Export données pour boards externes | INFRASTRUCTURE | à créer |
+| `boot-sequence/` | Initialisation système au démarrage | INFRASTRUCTURE | ✅ existant |
+| `process-scheduler/` | Cron + queue intents async | INFRASTRUCTURE | ✅ existant |
+| `ingestion-pipeline/` | Pipeline d'ingestion data externe | INFRASTRUCTURE | ✅ existant |
+| `quick-intake/` | Pipeline onboarding intake (rev 9) | INFRASTRUCTURE | ✅ existant |
+| `brief-ingest/` | Ingestion PDF briefs | MESTOR | ✅ existant |
+| `demo-data/` | Seeding pour staging/demo | INFRASTRUCTURE | ✅ existant |
+| `country-registry/` | Référentiel pays (devises, langues) | INFRASTRUCTURE | ✅ existant |
+| `translation/` | i18n service (P7) | INFRASTRUCTURE | ✅ existant |
+| `board-export/` | Export données pour boards externes | INFRASTRUCTURE | ✅ existant |
 | `mfa/` | TOTP-based MFA pour role ADMIN (Mission contribution: GROUND_INFRASTRUCTURE) | INFRASTRUCTURE | ✅ existant |
 | `collab-doc/` | Persistence layer collaborative StrategyDoc (load/save + optimistic concurrency, futur Yjs CRDT) | INFRASTRUCTURE | ✅ existant |
 
@@ -293,7 +293,7 @@ Propulsion 14 + Guidance 12 + Telemetry 21 + Sustainment 12 + Operations 10 + Cr
 = 90 répertoires sous src/server/services/  ✅
 ```
 
-**Manifests requis Phase 2** : 89 services métier × 1 manifest. Quelques services ont déjà un manifest partiel ou complet (`mestor/`, `seshat/`, `ptah/`, `imhotep/`, `anubis/`, `brand-vault/`, `error-vault/`, `sentinel-handlers/`, `monetization/`, `founder-psychology/`, `mfa/`, `collab-doc/`, `playbook-capitalization/`, `sector-intelligence/`). Le reste (~75 services) constitue le travail concret de Phase 2.6 du REFONTE-PLAN.
+**Manifests Phase 2 — ✅ COMPLETÉ** : tous les **89 services métier** + **1 stub utilitaire** (`nsp/`) ont leur `manifest.ts` co-localisé. Registry runtime (`__generated__/manifest-imports.ts`) recense **89 manifests** validés par `npm run manifests:audit`. Seul `utils/` reste sans manifest (helper transverse, pas un service au sens APOGEE — exclu par design). Phase 2.6 du REFONTE-PLAN refermée.
 
 ---
 

--- a/docs/governance/SERVICE-MAP.md
+++ b/docs/governance/SERVICE-MAP.md
@@ -1,12 +1,12 @@
 # SERVICE-MAP — Tous les services backend mappés sur APOGEE
 
-**90 services** sous `src/server/services/` (recensement Phase 15 — incl. `imhotep/`, `anubis/`, `ptah/`, `error-vault/` et services Phase 13). Chacun classé par **Sous-système APOGEE** + **Tier**. Le **Governor Neteru** indique sous quelle gouvernance le service tombe : MESTOR / ARTEMIS / SESHAT / THOT / **PTAH** (Phase 9) / **IMHOTEP** (Phase 14, ADR-0019) / **ANUBIS** (Phase 15, ADR-0020) / INFRASTRUCTURE.
+**90 répertoires** sous `src/server/services/` (recensement Phase 15 — incl. `imhotep/`, `anubis/`, `ptah/`, `error-vault/` et services Phase 13). Dont **89 services métier** classifiés par **Sous-système APOGEE** + **Tier**, et **1 répertoire helper** (`utils/`) hors classification. Le **Governor Neteru** indique sous quelle gouvernance le service tombe : MESTOR / ARTEMIS / SESHAT / THOT / **PTAH** (Phase 9) / **IMHOTEP** (Phase 14, ADR-0019) / **ANUBIS** (Phase 15, ADR-0020) / INFRASTRUCTURE.
 
 **Cap APOGEE atteint — 7/7 Neteru actifs** depuis Phase 14/15.
 
 Source de vérité : `find src/server/services -mindepth 1 -maxdepth 1 -type d`. Mis à jour avec [APOGEE.md](APOGEE.md) §4 + [PANTHEON.md](PANTHEON.md).
 
-Phase 2 du REFONTE-PLAN exige un `manifest.ts` co-localisé pour chaque service — la colonne **Manifest** indique l'état attendu (à créer ou existant).
+Phase 2 du REFONTE-PLAN exige un `manifest.ts` co-localisé pour chaque service métier — la colonne **Manifest** indique l'état attendu (à créer ou existant).
 
 ---
 
@@ -16,14 +16,14 @@ Phase 2 du REFONTE-PLAN exige un `manifest.ts` co-localisé pour chaque service 
 |---|---|---|---|
 | Propulsion (briefs) | M | 13 | ARTEMIS |
 | Propulsion (forge) | M | 1 (`ptah/` Phase 9 ✅ shipped) | **PTAH** (ADR-0009) |
-| Guidance | M | 13 | MESTOR |
-| Telemetry | M | 17 | SESHAT |
-| Sustainment | M | 8 | THOT / INFRASTRUCTURE |
-| Operations | G | 8 | THOT (extension) / INFRASTRUCTURE |
+| Guidance | M | 12 | MESTOR |
+| Telemetry | M | 21 | SESHAT |
+| Sustainment | M | 12 | THOT / MESTOR / INFRASTRUCTURE |
+| Operations | G | 10 | THOT (extension) / INFRASTRUCTURE |
 | Crew Programs | G | 5 satellites + `imhotep/` orchestrateur (Phase 14 ✅) | **IMHOTEP** (ADR-0019, supersedes ADR-0017) |
-| Comms | G | 3 satellites + `anubis/` orchestrateur (Phase 15 ✅) | **ANUBIS** (ADR-0020, supersedes ADR-0018) |
-| Admin | G | 8 | INFRASTRUCTURE |
-| **TOTAL** | | **90 services** | 7 Neteru actifs + INFRASTRUCTURE |
+| Comms | G | 2 satellites + `anubis/` orchestrateur (Phase 15 ✅) | **ANUBIS** (ADR-0020, supersedes ADR-0018) |
+| Admin | G | 11 | INFRASTRUCTURE |
+| **TOTAL** | | **89 services métier** + 1 helper (`utils/`) = **90 répertoires** | 7 Neteru actifs + INFRASTRUCTURE |
 
 ### Imhotep — service Phase 14 ✅ shipped (ADR-0019)
 
@@ -35,7 +35,7 @@ src/server/services/imhotep/
 └── types.ts                # payloads + back-compat ImhotepCrewProgramPlaceholder Phase 13
 ```
 
-Dépendances satellites : `matching-engine`, `talent-engine`, `team-allocator`, `tier-evaluator`, `qc-router`, `financial-brain`. **0 nouveau model Prisma** (anti-doublon NEFER §3) — réutilise TalentProfile, Course, Enrollment, TalentCertification, TalentReview, Mission, MissionDeliverable. Page hub : `/console/imhotep/page.tsx`. Router tRPC : `imhotep.ts`.
+Dépendances satellites : `matching-engine`, `talent-engine`, `team-allocator`, `tier-evaluator`, `qc-router`, `founder-psychology`, `financial-brain`. **0 nouveau model Prisma** (anti-doublon NEFER §3) — réutilise TalentProfile, Course, Enrollment, TalentCertification, TalentReview, Mission, MissionDeliverable. Page hub : `/console/imhotep/page.tsx`. Router tRPC : `imhotep.ts`.
 
 ### Anubis — service Phase 15 ✅ shipped (ADR-0020 + ADR-0021)
 
@@ -57,7 +57,7 @@ src/server/services/anubis/
     └── email-fallback.ts   # Dev mode (logs only)
 ```
 
-Dépendances satellites : `email`, `advertis-connectors`, `oauth-integrations`, `financial-brain`. **4 nouveaux models Prisma** : `CommsPlan`, `BroadcastJob`, `EmailTemplate`, `SmsTemplate`. Réutilise `Notification`, `NotificationPreference`, `WebhookConfig`, `ExternalConnector` existants. Pages : `/console/anubis/page.tsx` (dashboard) + `/console/anubis/credentials/page.tsx` (Credentials Center). Router tRPC : `anubis.ts`.
+Dépendances satellites : `email`, `oauth-integrations`, `advertis-connectors`, `financial-brain`. **4 nouveaux models Prisma** : `CommsPlan`, `BroadcastJob`, `EmailTemplate`, `SmsTemplate`. Réutilise `Notification`, `NotificationPreference`, `WebhookConfig`, `ExternalConnector` existants. Pages : `/console/anubis/page.tsx` (dashboard) + `/console/anubis/credentials/page.tsx` (Credentials Center). Router tRPC : `anubis.ts`.
 
 ### Ptah — service Phase 9 ✅ shipped (ADR-0009)
 
@@ -94,9 +94,9 @@ src/server/services/ptah/
 
 ---
 
-## 1. Propulsion (13 services — Mission Tier)
+## 1. Propulsion (14 services — Mission Tier)
 
-Génèrent la poussée vers l'apogée.
+Génèrent la poussée vers l'apogée. **13 services briefs (ARTEMIS) + 1 service forge (PTAH)**.
 
 | Service | Rôle propulsion | Governor | Manifest |
 |---|---|---|---|
@@ -113,10 +113,11 @@ Génèrent la poussée vers l'apogée.
 | `guidelines-renderer/` | Rendu brand guidelines (livrable) | ARTEMIS | à créer |
 | `value-report-generator/` | Rendu rapport valeur (livrable client) | ARTEMIS | à créer |
 | `seshat-bridge/` | **Bridge** Telemetry → Propulsion (signaux qui déclenchent missions) | ARTEMIS | à créer |
+| `ptah/` | **Forge orchestrator** — matérialise les briefs en assets (image/video/audio/icon/refine/...) | **PTAH** (ADR-0009) | ✅ existant |
 
 ---
 
-## 2. Guidance (13 services — Mission Tier)
+## 2. Guidance (12 services — Mission Tier)
 
 Dirigent la trajectoire. Décisions, validations, plans.
 
@@ -125,7 +126,6 @@ Dirigent la trajectoire. Décisions, validations, plans.
 | `mestor/` | Computer de guidage central — Intent dispatcher (`emitIntent`) | MESTOR | partiel (`intents.ts:179`) |
 | `pillar-gateway/` | Écriture gouvernée des Pillars (`writePillarAndScore`) | MESTOR | à créer |
 | `pillar-maturity/` | Évaluation maturity N0-N6 + assessor | MESTOR | à créer |
-| `pillar-readiness/` | (vit dans `governance/`) — 5 gates de pre-conditions | MESTOR | gov layer |
 | `pillar-versioning/` | Versionning des contrats Pillar | MESTOR | à créer |
 | `pillar-normalizer/` | Normalisation inputs avant write | MESTOR | à créer |
 | `rtis-protocols/` | Protocoles cascade R-T-I-S | MESTOR | à créer |
@@ -133,14 +133,18 @@ Dirigent la trajectoire. Décisions, validations, plans.
 | `cross-validator/` | Validation cross-pillar cohérence | MESTOR | à créer |
 | `vault-enrichment/` | Enrichissement strategy depuis vault | MESTOR | à créer |
 | `strategy-presentation/` | Assemblage Oracle 21 sections + catalogue `OracleError` (ADR-0022) | MESTOR | à créer |
-| `strategy-presentation/error-codes.ts` | Catalogue typé `ORACLE-NNN` + classe `OracleError` + `toOracleError` (ADR-0022) | MESTOR | n/a (helper) |
-| `strategy-presentation/error-capture.ts` | `captureOracleErrorPublic` → error-vault (recursion-safe) | MESTOR | n/a (helper) |
 | `prompt-registry/` | Registre prompts LLM versionnés | MESTOR | à créer |
 | `staleness-propagator/` | Détecte et propage staleness | MESTOR | à créer |
 
+> Helpers TS dans `strategy-presentation/` (n/a manifest, n/a count) :
+> - `error-codes.ts` — catalogue typé `ORACLE-NNN` + classe `OracleError` + `toOracleError` (ADR-0022)
+> - `error-capture.ts` — `captureOracleErrorPublic` → error-vault (recursion-safe)
+>
+> **Note** : `pillar-readiness/` vit dans `src/server/governance/` (5 gates pre-conditions) — pas un service `src/server/services/`, donc hors compte.
+
 ---
 
-## 3. Telemetry (17 services — Mission Tier)
+## 3. Telemetry (21 services — Mission Tier)
 
 Observent, mesurent, archivent.
 
@@ -152,6 +156,9 @@ Observent, mesurent, archivent.
 | `knowledge-capture/` | Capture nouveaux knowledge entries | SESHAT | à créer |
 | `knowledge-seeder/` | Seeding knowledge initial | SESHAT | à créer |
 | `market-intelligence/` | Intel sectorielle | SESHAT | à créer |
+| `sector-intelligence/` | Sector as first-class entity (APOGEE drift 5.2 fix) | SESHAT | ✅ existant |
+| `source-classifier/` | Reads BrandDataSource → BrandAsset DRAFTs (taxonomie canonique) | SESHAT | à créer |
+| `playbook-capitalization/` | Cross-brand learning loop (MISSION drift 5.10) | SESHAT | ✅ existant |
 | `audit-trail/` | Trail audit transverse | INFRASTRUCTURE | à créer |
 | `ecosystem-engine/` | Moteur métriques cross-tenant | SESHAT | à créer |
 | `ai-cost-tracker/` | Tracking coûts LLM par intent | THOT | à créer |
@@ -163,29 +170,36 @@ Observent, mesurent, archivent.
 | `feedback-loop/` | Boucle feedback Mestor ↔ Seshat | SESHAT | à créer |
 | `feedback-processor/` | Traitement feedbacks structurés | SESHAT | à créer |
 | `asset-tagger/` | Tagging automatique assets | SESHAT | à créer |
+| `error-vault/` | Collecteur erreurs runtime (server/client/Prisma/NSP/Ptah/cron/webhook) — Phase 11 | SESHAT | ✅ existant |
 
 ---
 
-## 4. Sustainment (8 services — Mission Tier)
+## 4. Sustainment (12 services — Mission Tier)
 
-Maintiennent la mission viable techniquement.
+Maintiennent la mission viable techniquement. Mémoires long terme, transports, gates de capacité, sentinels.
 
 | Service | Rôle sustainment | Governor | Manifest |
 |---|---|---|---|
 | `llm-gateway/` | Engine controller multi-provider (v4) | INFRASTRUCTURE | à créer |
+| `model-policy/` | Résolution gouvernée `purpose → model` (cache + Prisma `ModelPolicy`) | INFRASTRUCTURE | à créer |
 | `financial-brain/` | **Thot** — fuel manager, capacity tracking | THOT | à créer |
 | `budget-allocator/` | Allocation budget par mission | THOT | à créer |
 | `approval-workflow/` | Workflow d'approbation pré-action | MESTOR | à créer |
 | `sla-tracker/` | SLO/SLA tracking par Intent kind | INFRASTRUCTURE | à créer |
 | `operator-isolation/` | Tenant isolation (default-deny) | INFRASTRUCTURE | à créer |
 | `neteru-shared/` | Governance registry central | INFRASTRUCTURE | manifests des autres |
-| `cross-validator/` | (déjà compté en Guidance — invariants techniques) | MESTOR | — |
+| `brand-vault/` | BrandAsset CRUD engine — vault unifié (ADR-0012, Phase 10) | MESTOR | ✅ existant |
+| `strategy-archive/` | 2-phase soft archive + hard purge (`Strategy.archivedAt`) | INFRASTRUCTURE | à créer |
+| `sentinel-handlers/` | Handlers cron `/api/cron/sentinels` — consomme IntentEmission PENDING (Loi 4 maintien orbite) | MESTOR | ✅ existant |
+| `nsp/` | Neteru Streaming Protocol — transport publish/subscribe vers UI | INFRASTRUCTURE | n/a (utilitaire pur) |
+
+> `cross-validator/` est compté en Guidance (rôle dominant : validation cross-pillar). Ses invariants techniques sont consommés par Sustainment — pas de double-count.
 
 ---
 
-## 5. Operations (8 services — Ground Tier)
+## 5. Operations (10 services — Ground Tier)
 
-Argent, contrats, facturation. Sans Operations, pas de business.
+Argent, contrats, facturation, monétisation. Sans Operations, pas de business.
 
 | Service | Rôle operations | Governor | Manifest |
 |---|---|---|---|
@@ -193,6 +207,8 @@ Argent, contrats, facturation. Sans Operations, pas de business.
 | `financial-engine/` | Logique business financière | THOT | à créer |
 | `financial-reconciliation/` | Réconciliation transactions | THOT | à créer |
 | `mobile-money/` | Intégration paiement mobile (Orange/MTN/Wave) | INFRASTRUCTURE | à créer |
+| `payment-providers/` | Registry abstrait providers paiement (`pickProvider()`) | INFRASTRUCTURE | à créer |
+| `monetization/` | Pricing localisé marché (FMCG / SaaS / agence — Mission contribution: GROUND_INFRASTRUCTURE) | THOT | ✅ existant |
 | `crm-engine/` | Relation client structurée | INFRASTRUCTURE | à créer |
 | `upsell-detector/` | Signaux d'upgrade contractuel | SESHAT | à créer |
 | `campaign-budget-engine/` | Budgets par campagne | THOT | à créer |
@@ -200,22 +216,38 @@ Argent, contrats, facturation. Sans Operations, pas de business.
 
 ---
 
-## 6. Crew Programs (4 services — Ground Tier)
+## 6. Crew Programs (6 services — Ground Tier)
 
-Talent, formation, matching, QC.
+Talent, formation, matching, QC, psychologie founder. **5 satellites + `imhotep/` orchestrateur**.
 
 | Service | Rôle crew programs | Governor | Manifest |
 |---|---|---|---|
+| `imhotep/` | **Orchestrateur** — wrappe matching/talent/team/tier/qc, formation Académie (Phase 14, ADR-0019) | **IMHOTEP** | ✅ existant |
 | `talent-engine/` | Évaluation, scoring, ranking creators | INFRASTRUCTURE | à créer |
 | `matching-engine/` | Match creator ↔ mission | INFRASTRUCTURE | à créer |
 | `team-allocator/` | Composition d'équipes optimales | INFRASTRUCTURE | à créer |
 | `qc-router/` | Routing quality control | INFRASTRUCTURE | à créer |
+| `founder-psychology/` | Mécanise "founder = first superfan" (MISSION drift 5.9) | INFRASTRUCTURE | ✅ existant |
 
 ---
 
-## 7. Admin (8 services — Ground Tier)
+## 7. Comms (3 services — Ground Tier)
 
-Configuration, boot, ingestion système, support.
+Channels externes vers audience. Ad networks, email, SMS, OAuth flows. **2 satellites + `anubis/` orchestrateur**.
+
+| Service | Rôle comms | Governor | Manifest |
+|---|---|---|---|
+| `anubis/` | **Orchestrateur** — broadcast multi-canal, ad networks, Credentials Vault (Phase 15, ADR-0020 + ADR-0021) | **ANUBIS** | ✅ existant |
+| `email/` | Email transactionnel (Resend / SendGrid / SES + dev fallback console) | ANUBIS | à créer |
+| `oauth-integrations/` | OAuth 2.0 Authorization Code flow pour intégrations sortantes (Google, LinkedIn, Meta) | ANUBIS | à créer |
+
+> Provider façades (Meta Ads, Google Ads, X Ads, TikTok Ads, Mailgun, Twilio) sont co-localisées dans `anubis/providers/` — pas comptées comme services distincts (sub-modules de l'orchestrateur).
+
+---
+
+## 8. Admin (11 services — Ground Tier)
+
+Configuration, boot, ingestion système, support, security, collaboration interne.
 
 | Service | Rôle admin | Governor | Manifest |
 |---|---|---|---|
@@ -228,38 +260,53 @@ Configuration, boot, ingestion système, support.
 | `country-registry/` | Référentiel pays (devises, langues) | INFRASTRUCTURE | à créer |
 | `translation/` | i18n service (P7) | INFRASTRUCTURE | à créer |
 | `board-export/` | Export données pour boards externes | INFRASTRUCTURE | à créer |
-| `utils/` | Helpers transverses | INFRASTRUCTURE | n/a (pas un service) |
+| `mfa/` | TOTP-based MFA pour role ADMIN (Mission contribution: GROUND_INFRASTRUCTURE) | INFRASTRUCTURE | ✅ existant |
+| `collab-doc/` | Persistence layer collaborative StrategyDoc (load/save + optimistic concurrency, futur Yjs CRDT) | INFRASTRUCTURE | ✅ existant |
+
+> Helper hors compte : `utils/` — helpers transverses, pas un service au sens APOGEE.
 
 ---
 
-## 8. Verdict — orphelins révélés
+## 9. Verdict — orphelins révélés
 
-Aucun service n'est resté orphelin :
+Aucun service n'est resté orphelin après Phase 14/15 et Phase 16 :
 
-- Tous les services financiers (`financial-*`, `commission-engine`, `mobile-money`, `crm-engine`, `upsell-detector`, `campaign-budget-engine`, `data-export`) → absorbés par **Operations**.
-- Tous les services humains (`talent-engine`, `matching-engine`, `team-allocator`, `qc-router`) → absorbés par **Crew Programs**.
-- Tous les services d'infrastructure (`boot-sequence`, `process-scheduler`, `ingestion-pipeline`, `country-registry`, `translation`, etc.) → absorbés par **Admin**.
+- Tous les services financiers (`financial-*`, `commission-engine`, `mobile-money`, `payment-providers`, `monetization`, `crm-engine`, `upsell-detector`, `campaign-budget-engine`, `data-export`) → absorbés par **Operations** (10 services).
+- Tous les services humains (`talent-engine`, `matching-engine`, `team-allocator`, `qc-router`, `founder-psychology`) + `imhotep/` orchestrateur → absorbés par **Crew Programs** (6 services).
+- Tous les services de communication externe (`email`, `oauth-integrations`) + `anubis/` orchestrateur → absorbés par **Comms** (3 services).
+- Tous les services d'infrastructure (`boot-sequence`, `process-scheduler`, `ingestion-pipeline`, `country-registry`, `translation`, `mfa`, `collab-doc`, etc.) → absorbés par **Admin** (11 services).
+- Tous les services de mémoire long terme + transport + sentinels (`brand-vault`, `strategy-archive`, `nsp`, `sentinel-handlers`, `model-policy`) → absorbés par **Sustainment** (12 services).
 
 **Cas particuliers** :
 
-- `seshat-bridge/` — **services pont** entre 2 sous-systèmes (Telemetry → Propulsion). Pattern récurrent où une observation Seshat déclenche une action Artemis. Modélisé dans Propulsion (output) avec governor SESHAT.
-- `cross-validator/` — sert à la fois Guidance (validation cross-pillar) et Sustainment (invariants techniques). Listé en Guidance (rôle dominant).
-- `utils/` — pas un service au sens APOGEE, juste des helpers. Reste hors classification.
+- `seshat-bridge/` — **service pont** entre 2 sous-systèmes (Telemetry → Propulsion). Pattern récurrent où une observation Seshat déclenche une action Artemis. Listé en Propulsion (output) avec governor SESHAT.
+- `cross-validator/` — sert à la fois Guidance (validation cross-pillar) et Sustainment (invariants techniques). Listé en Guidance (rôle dominant) — pas de double-count.
+- `nsp/` — utilitaire pur de transport (pas une capability métier, pas de manifest). Compté en Sustainment (transport infra transversale).
+- `utils/` — helpers TS, pas un service au sens APOGEE. Compté comme répertoire (1) mais pas comme service métier (0).
 
-**Manifests requis Phase 2** : 71 services × 1 manifest = **71 manifests à créer** (10 jours estimés). C'est le travail concret de Phase 2.6 du REFONTE-PLAN.
+**Vérification arithmétique** :
+
+```
+Propulsion 14 + Guidance 12 + Telemetry 21 + Sustainment 12 + Operations 10 + Crew 6 + Comms 3 + Admin 11
+= 89 services métier classifiés
++ 1 helper (utils/)
+= 90 répertoires sous src/server/services/  ✅
+```
+
+**Manifests requis Phase 2** : 89 services métier × 1 manifest. Quelques services ont déjà un manifest partiel ou complet (`mestor/`, `seshat/`, `ptah/`, `imhotep/`, `anubis/`, `brand-vault/`, `error-vault/`, `sentinel-handlers/`, `monetization/`, `founder-psychology/`, `mfa/`, `collab-doc/`, `playbook-capitalization/`, `sector-intelligence/`). Le reste (~75 services) constitue le travail concret de Phase 2.6 du REFONTE-PLAN.
 
 ---
 
-## 9. Services manquants (à anticiper)
+## 10. Services manquants (à anticiper)
 
-Selon l'extension framework, certains services sont *attendus mais pas encore présents* :
+La matrice 8×N est désormais complète depuis Phase 14/15/16. Aucun sous-système n'est vide.
+
+Services restant à anticiper (extension framework) :
 
 | Service attendu | Sous-système | Phase | Justification |
 |---|---|---|---|
-| `messaging/` | Comms | P5 | Comms est un sous-système sans service core encore — vit dans routers seuls |
-| `notification/` | Comms | P5 | Idem |
-| `nsp/` (NSP server) | Telemetry/governance | P5 | Neteru Streaming Protocol côté serveur |
-| `cost-gate/` | Sustainment | P3 | Pillar 6 (Thot active gate) |
-| `compensating-intents/` | Sustainment | P3 | Reverse maneuvers |
+| `compensating-intents/` | Sustainment | P3+ | Reverse maneuvers Loi 1 (extension `sentinel-handlers`) |
+| `cost-gate/` | Sustainment | P3+ | Pillar 6 (Thot active gate dédié — actuellement délégué à `financial-brain.checkCapacity` + `budget-allocator`) |
+| `notification/` | Comms | P5+ | Notification center cross-channel (actuellement via `nsp/` transport + `anubis/` broadcast) |
 
-Ces 5 services arriveront en Phase 3-5 du plan de refonte. Ils complètent la matrice 8×8 du framework.
+Ces 3 services optionnels arriveront uniquement si pattern d'extraction émerge — ils ne sont pas bloquants pour la complétude APOGEE. La cap 7/7 Neteru actifs reste maintenue (pas de 8ème Neter).

--- a/docs/governance/adr/0030-intake-closure-adve-100pct.md
+++ b/docs/governance/adr/0030-intake-closure-adve-100pct.md
@@ -1,0 +1,222 @@
+# ADR-0030 — Intake closure : ADVE 100% par design + gate `actualizeRT` sur RTIS_CASCADE
+
+**Date** : 2026-05-03
+**Statut** : proposed
+**Phase de refonte** : phase/2-intents
+**Précédé par** : ADR-0023 (`OPERATOR_AMEND_PILLAR` voie unique d'édition ADVE), v6.1.18 (fix `rtis-cascade.savePillar` cache reconciliation)
+**Auteur** : NEFER (session enquête stepper Notoria, 2026-05-03)
+
+---
+
+## TL;DR
+
+L'intake landing produit aujourd'hui des piliers ADVE **sparse par design** (3-4 champs/pilier, `currentStage = INTAKE` ou `EMPTY`). Le bouton "Enrichir" sur la page pilier plafonne à un % qui exclut les champs `derivable: false` du contrat de maturité. Conséquence : la cascade R+T part de matière incomplète, le stepper Notoria se bloque, l'opérateur ne sait pas où cliquer pour fermer l'écart.
+
+**Décision** : refondre le tunnel intake → vault → cascade en 3 axes coordonnés pour que la chaîne `intake → ADVE 100% → R+T → I → S` soit déterministe et que l'opérateur soit guidé sans deviner.
+
+---
+
+## Contexte (diagnostic NEFER 2026-05-03)
+
+### Symptôme observé
+
+Sur cockpit `/cockpit/brand/identity` (pilier A) d'une marque post-intake :
+- **Suffisant 79%** (ENRICHED stage)
+- **Complet 81%** (COMPLETE stage)
+- **R+T —** (cascade pas consolidée)
+- Champs visibles vides : `Accroche`, et plusieurs champs `needsHuman` invisibles côté UI
+
+Le bouton **"Enrichir"** (rouge, ADVE) ne fait pas progresser le score.
+Le bouton **"Lancer la veille R+T"** sur Notoria fait avancer R+T mais sur du sable (ADVE incomplet → recos R+T mediocres).
+
+### Chaîne causale (5-WHY)
+
+1. **Stepper Notoria bloqué étape 1** → `dashboard.completionLevels.r === "INCOMPLET"`
+2. **R/T en INCOMPLET** → `Pillar.completionLevel` cache pas reconcilié après `actualizeRT` *(fix v6.1.18 `writePillarAndScore` ✓)*
+3. **Même après v6.1.18, R/T pas en COMPLET** → `assessPillar` retourne `currentStage = INTAKE` (R/T sparse)
+4. **R/T sparse** → cascade RTIS partie de ADVE sparse, LLM produit JSON minimal cohérent avec le manque
+5. **ADVE sparse** → intake produit `currentStage = INTAKE` ou `EMPTY` après écriture
+6. **Intake produit ADVE sparse** → (a) question-bank ne couvre pas tous les `derivable: false`, (b) AI extraction délibérément conservatrice
+7. **Décision design "anti-hallucination"** sans contrepartie compensatoire → champs `needsHuman` jamais saisis
+
+### Chiffrage du gap intake
+
+Source : [pillar-maturity-contracts.ts:20-46](../../../src/lib/types/pillar-maturity-contracts.ts) + [question-bank.ts](../../../src/server/services/quick-intake/question-bank.ts).
+
+| Pilier | Q intake | Champs INTAKE `derivable: false` | Couverts par Q dédiée ? | Couverts par seal canonical ? |
+|---|---|---|---|---|
+| **A** | 5 (`a_vision`, `a_mission`, `a_origin`, `a_values`, `a_archetype`) | `archetype`, `noyauIdentitaire`, `citationFondatrice` | `archetype` ✓ | aucun |
+| **D** | 4 | `positionnement`, `promesseMaitre`, `personas` | aucun direct | `positionnement` partiel (BusinessContext.positioning ≠ `D.positionnement` champ ENRICHED) |
+| **V** | 3 | `produitsCatalogue`, `businessModel` | aucun direct | `businessModel` ✓ (déclaré au start) |
+| **E** | 9 | (aucun `derivable: false`) | n/a | n/a |
+
+**Verdict** : **5 champs `needsHuman` du contrat INTAKE ne sont jamais demandés à l'utilisateur ni dérivés** : `noyauIdentitaire`, `citationFondatrice`, `D.positionnement` (champ ENRICHED, pas le BusinessContext), `D.promesseMaitre`, `D.personas`, `V.produitsCatalogue`. L'AI extraction peut les deviner si l'utilisateur a lâché du contenu utilisable, sinon ils restent vides → INTAKE échoue → `currentStage = EMPTY`.
+
+### Drift architectural collatéral
+
+[notoria.ts:83-96](../../../src/server/trpc/routers/notoria.ts) : la mutation `actualizeRT` n'a **pas** de `preconditions`. Elle est appelable même si A/D/V/E sont à `INTAKE`. Comparé à [notoria.ts:64](../../../src/server/trpc/routers/notoria.ts) (`generateBatch` qui a `preconditions: ["RTIS_CASCADE"]`), c'est une **incohérence de governance** : deux mutations qui touchent la même cascade obéissent à des règles différentes.
+
+Le gate `RTIS_CASCADE` est défini canoniquement ([pillar-readiness.ts:194-202](../../../src/server/governance/pillar-readiness.ts)) :
+
+```ts
+RTIS_CASCADE: verdict(
+  (stage === "ENRICHED" || stage === "COMPLETE") && !stale,
+  ...
+),
+```
+
+→ Pour qu'on puisse cascader R/T depuis un pilier ADVE, il faut au minimum `stage === ENRICHED`. `actualizeRT` viole ce contrat aujourd'hui.
+
+### Drift narratif collatéral (NEFER §3 interdit #1)
+
+L'auto-filler [auto-filler.ts:80-83](../../../src/server/services/pillar-maturity/auto-filler.ts) ignore silencieusement les `needsHuman` (`continue;` sur `!req.derivable`), mais **ne remonte rien à l'UI**. Le `pillar-page.tsx` n'affiche jamais `assess.needsHuman[]` à l'utilisateur. Le système connaît exactement ce qui bloque mais le cache. C'est une asymétrie d'information qui force l'opérateur à jouer aux devinettes — exactement ce que NEFER mantra interdit ("avant de coder, je vérifie" → mais ici l'opérateur ne PEUT pas vérifier).
+
+---
+
+## Décision
+
+3 axes coordonnés, séquencés Axe 1 → Axe 3 → Axe 2 (impact croissant, refonte UX → governance → produit).
+
+### Axe 1 — UX `needsHuman` panel (résout l'asymétrie d'information)
+
+**Sur `pillar-page.tsx`, ajouter un panneau encart sous le scoring bar** quand `assess.needsHuman.length > 0`, qui :
+
+1. Liste explicitement les champs manquants (label depuis `variable-bible.BIBLE_X.{path}.label`).
+2. Pour chaque champ : un CTA **"Saisir"** qui ouvre `AmendPillarModal` pré-ciblé sur ce champ (mode `PATCH_DIRECT` par défaut, `LLM_REPHRASE` si champ texte qualitatif >50 chars).
+3. Précise `derivable: 'human'` vs `derivable: false` dans le contrat → expliquer pourquoi l'auto-fill ne peut pas les remplir.
+4. Indicateur visuel : *"X champs essentiels non saisis — Enrichir ne pourra pas atteindre 100% sans ta saisie."*
+
+Modification du bouton **"Enrichir"** : si `needsHuman.length > 0`, tooltip change : *"Enrichir remplit les {N} champs dérivables. {M} autres champs nécessitent ta saisie — voir liste ci-dessous."*. Le bouton fonctionne quand même (utile pour pré-remplir les `derivable: true`).
+
+**Impact** : aucun changement de governance. Pure UI/UX. ~150 lignes dans `pillar-page.tsx` + petite modif `AmendPillarModal` pour pré-cibler un champ via prop `initialField?: string`.
+
+### Axe 2 — Closure intake question-bank (résout la cause racine)
+
+**Compléter [question-bank.ts](../../../src/server/services/quick-intake/question-bank.ts) pour que 100% des `derivable: false` du contrat INTAKE soient adressés** par une question directe ou par un seal canonical existant.
+
+| Champ manquant | Action |
+|---|---|
+| `A.noyauIdentitaire` | Nouvelle Q `a_noyau` : *"Si vous deviez résumer votre marque en une phrase identitaire de moins de 20 mots, ce serait quoi ?"* — `required: true`, `min_length: 10` |
+| `A.citationFondatrice` | Nouvelle Q `a_citation` : *"Quelle citation, maxime ou phrase manifeste résume l'esprit fondateur de votre marque ?"* — `required: false` (peut être laissé pour AI rephrase depuis `a_origin`) mais marqué `derivable: true via cross_pillar` dans le contrat |
+| `D.positionnement` | Nouvelle Q `d_positioning_explicit` : *"Comment positionnez-vous explicitement votre marque par rapport à vos 2 principaux concurrents ?"* — `required: true` |
+| `D.promesseMaitre` | Nouvelle Q `d_promise` : *"Quelle est votre promesse maître — ce que le client peut attendre de vous, sans condition ?"* — `required: true` |
+| `D.personas` | Nouvelle Q `d_persona_principal` : *"Décrivez votre client idéal en 3 traits comportementaux concrets (pas démographiques)"* + Q `d_persona_secondary` optionnelle. Output structuré → array d'1 ou 2 personas. |
+| `V.produitsCatalogue` | Nouvelle Q `v_produits` : *"Listez vos 3-5 produits/services principaux avec leur prix indicatif (un par ligne)"* — `required: true`, parser ligne → `{nom, prix}` |
+
+**Bonus mécanique** : changer le contrat A pour rendre `noyauIdentitaire` et `citationFondatrice` `derivable: true` avec `derivationSource: "cross_pillar"` (depuis `a_vision`/`a_mission`/`a_origin`) → fallback gracieux si l'utilisateur les saute. Mais le default reste **demander explicitement**, pas deviner.
+
+**Impact** : changement produit (touche le funnel intake landing user-facing). Tests à ajouter : intake E2E qui finit avec ADVE en `currentStage === "INTAKE"` minimum (gate `assertReadyFor("RTIS_CASCADE")` doit passer).
+
+### Axe 3 — Gate `actualizeRT` sur `RTIS_CASCADE` (anti-drift LOI 1)
+
+**Modifier [notoria.ts:83-96](../../../src/server/trpc/routers/notoria.ts)** pour ajouter `preconditions: ["RTIS_CASCADE"]` au `actualizeRT` operatorProcedure, alignant son comportement sur `generateBatch` (ligne 64).
+
+```ts
+actualizeRT: operatorProcedure
+  .input(z.object({
+    strategyId: z.string(),
+    pillars: z.array(z.enum(["R", "T"])).default(["R", "T"]),
+  }))
+  .preconditions(["RTIS_CASCADE"])  // ← AJOUT
+  .mutation(async ({ input }) => { ... }),
+```
+
+**Côté UI** : sur `notoria-page.tsx`, le bouton "Lancer la veille R + T" est désactivé (avec tooltip explicatif) si `assess.gates.RTIS_CASCADE.ok === false`. Lien "Compléter ADVE d'abord" qui scroll vers les piliers ADVE non-prêts. Le stepper UI reflète : étape 1 = "ADVE → ENRICHED" au lieu de "Risque + Track" (renumérotation conceptuelle), R+T devient étape 2.
+
+**Impact** : refonte du stepper Notoria à 5 étapes au lieu de 4, mais reflète la réalité de la cascade. Architecturalement clean : zéro chemin contournable.
+
+### Axe 4 (optionnel, hors scope ce ADR) — `auto-filler` retourne `needsHuman` aux mutations
+
+Aujourd'hui [pillar.autoFill](../../../src/server/trpc/routers/pillar.ts) retourne `{ filled, failed, needsHuman, newStage }`. Le client (`handleRegenerate` dans `pillar-page.tsx`) n'utilise que `filled`. À explorer dans un sprint UX ultérieur : surfacer `needsHuman` dans le toast de feedback du bouton Enrichir pour que l'utilisateur soit prévenu **immédiatement** après le clic.
+
+---
+
+## Conséquences
+
+### Avant cet ADR
+- Intake produit ADVE sparse → cascade R+T sur du sable → Oracle/SuperAssets construits sur fondations fragiles → la chaîne ADVERTIS est mathématiquement incomplète.
+- L'opérateur ne sait pas pourquoi son pilier est à 81% et pas 100%.
+- `actualizeRT` peut être invoqué sur ADVE vide → produit du JSON LLM générique.
+
+### Après cet ADR
+- Intake produit ADVE en `currentStage === "INTAKE"` minimum (tous champs `derivable: false` couverts).
+- Le bouton "Enrichir" peut amener à `ENRICHED` (les champs ENRICHED sont presque tous `derivable: true`).
+- Les champs ENRICHED restants `needsHuman` sont **explicitement listés à l'utilisateur** avec CTA direct.
+- `actualizeRT` refuse de tourner si ADVE pas prêt → R+T toujours sur matière dense → recos qualité.
+- Le stepper Notoria reflète honnêtement les étapes : ADVE → R+T → I → S, pas R+T en premier.
+
+### Compatibilité existant
+
+- **Intakes existants** (Strategy avec content sparse) : pas affectés rétroactivement. Le gate `RTIS_CASCADE` les bloquera sur `actualizeRT` côté UI — il faut soit compléter manuellement via amend, soit relancer l'intake. À documenter dans une note runbook.
+- **Strategies seedées** (`seed-spawt-complete.ts`, `seed-wakanda`) : à auditer post-ADR pour s'assurer qu'elles passent `RTIS_CASCADE`. Si non, ajouter du contenu seed pour les `derivable: false` du contrat INTAKE.
+- **Schema Zod** ([pillar-schemas.ts](../../../src/lib/types/pillar-schemas.ts)) : aucun changement. Les nouveaux paths intake correspondent à des champs Zod déjà définis (`noyauIdentitaire`, `citationFondatrice`, etc.) — l'ADR ne fait que **les peupler** systématiquement.
+- **`OPERATOR_AMEND_PILLAR`** (ADR-0023) : déjà la voie unique d'amendement. Cet ADR-0030 ajoute simplement des CTA UI qui le déclenchent depuis la liste `needsHuman`.
+
+### Tests à ajouter
+
+1. `tests/integration/intake-completes-adve.test.ts` — un intake avec réponses minimales (1 mot par Q) doit produire ADVE A/D/V/E en `currentStage === "INTAKE"` minimum (tous `derivable: false` remplis).
+2. `tests/integration/actualize-rt-gated.test.ts` — `actualizeRT` doit throw `ReadinessVetoError` si A est `EMPTY`, et passer si A/D/V/E sont `ENRICHED`.
+3. `tests/unit/pillar-page-needs-human-panel.test.tsx` — le panneau `needsHuman` s'affiche correctement et les CTA "Saisir" ouvrent le modal pré-ciblé.
+
+### Audits anti-drift
+
+- Étendre `scripts/audit-mission-drift.ts` (ou créer `scripts/audit-intake-coverage.ts`) qui vérifie : pour chaque pilier ADVE, **chaque champ `derivable: false` du contrat INTAKE doit être couvert** soit par une question dans `question-bank.ts`, soit par un seal canonical, soit par un `derivationSource` non-`ai_generation` (calculation/cross_pillar) — sinon échoue CI. Empêche la régression future.
+
+---
+
+## Plan d'implémentation (séquencé, 3 PRs)
+
+### PR-1 — Axe 1 UX `needsHuman` panel (~150 lignes, 0 risque)
+- `pillar-page.tsx` : panneau encart sous scoring bar, conditionnel `assess.needsHuman.length > 0`.
+- `amend-pillar-modal.tsx` : prop `initialField?: string` qui pré-sélectionne le dropdown.
+- `variable-bible.ts` : ajouter `label` sur les paths qui n'en ont pas (utilisé pour rendre les noms lisibles dans le panel).
+- CHANGELOG `feat(cockpit): needsHuman panel + CTA direct sur page pilier`.
+
+### PR-2 — Axe 3 gate `actualizeRT` (anti-drift, ~30 lignes)
+- `notoria.ts` : ajouter `preconditions: ["RTIS_CASCADE"]` à `actualizeRT`.
+- `notoria-page.tsx` : disable bouton "Lancer la veille R+T" si `gate RTIS_CASCADE` failed + tooltip explicatif + lien "Compléter ADVE".
+- `notoria-page.tsx` : refonte stepper 4→5 étapes (ADVE → R+T → I → S, ADVE devient étape 1).
+- Test `tests/integration/actualize-rt-gated.test.ts`.
+- CHANGELOG `fix(notoria): gate actualizeRT par RTIS_CASCADE + stepper 5-étapes`.
+
+### PR-3 — Axe 2 closure intake question-bank (refonte produit, ~300 lignes)
+- `question-bank.ts` : 6 nouvelles questions (cf. tableau §Décision Axe 2).
+- `quick-intake/index.ts` : adapter `extractStructuredPillarContent` prompt pour mentionner explicitement les nouveaux paths attendus + parsing personnel/produits.
+- `pillar-maturity-contracts.ts` : marquer `noyauIdentitaire`/`citationFondatrice` `derivable: true via cross_pillar` (fallback gracieux).
+- `intake/[token]/page.tsx` (UI landing) : rendu adapté aux nouvelles Q (label, tooltip, validation).
+- `tests/integration/intake-completes-adve.test.ts`.
+- `scripts/audit-intake-coverage.ts` (nouveau) + entry CI.
+- CHANGELOG `feat(intake): closure ADVE 100% — questions needsHuman + audit coverage`.
+
+---
+
+## Risques et mitigations
+
+| Risque | Mitigation |
+|---|---|
+| Allongement du tunnel intake landing (6 Q en plus) → drop-off conversion | Phasage progressif : Q `required: true` minimum (3 nouvelles : `a_noyau`, `d_positioning_explicit`, `v_produits`), les autres en `required: false` avec hint "saute si tu veux passer plus vite, tu pourras compléter dans le cockpit". A/B testable. |
+| Strategies existantes en base avec ADVE sparse → bloquées sur `actualizeRT` | Runbook + script `scripts/migrate-existing-strategies-coverage.ts` qui scan les strategies, détecte celles avec `gate RTIS_CASCADE failed`, et soit (a) prévient l'utilisateur via notification, soit (b) auto-amende via LLM extraction depuis `quickIntake.responses` historiques. |
+| Stepper 5-étapes trop chargé visuellement | Première étape "ADVE" reste cliquable et expand pour montrer A/D/V/E individuellement (sub-stepper). |
+| Audit `scripts/audit-intake-coverage.ts` faux positifs sur futurs ajouts contract | Test invariant + section dédiée dans NEFER §4.5. |
+
+---
+
+## Décisions explicitement REJETÉES
+
+- **Rendre tous les champs `derivable: true` et confier à l'AI** → rejeté. Casse le principe anti-hallucination de l'intake. Les champs identitaires (`noyauIdentitaire`, `citationFondatrice`, `positionnement`, `promesseMaitre`) DOIVENT venir de l'humain — ce sont les fondations de la marque.
+- **Forcer 100% à l'intake (refus de soumettre tant qu'incomplet)** → rejeté. Trop de friction landing. La progression intake → cockpit avec amend ultérieur est le bon flow.
+- **Supprimer le concept `derivable: false`** → rejeté. C'est une distinction utile pour le moteur. Il faut juste que l'UX en tire les conséquences.
+- **Réorganiser les contrats pour mettre tous les `derivable: false` en stage ENRICHED au lieu de INTAKE** → rejeté. INTAKE doit rester le seuil minimal viable de la marque. Si on permet INTAKE sans `noyauIdentitaire`, on permet une marque sans noyau identitaire — c'est absurde au regard de la mission ADVERTIS.
+
+---
+
+## Références
+
+- [ADR-0023](0023-operator-amend-pillar.md) — `OPERATOR_AMEND_PILLAR` : voie unique d'édition ADVE
+- [pillar-readiness.ts](../../../src/server/governance/pillar-readiness.ts) — gates canoniques (`DISPLAY_AS_COMPLETE`, `RTIS_CASCADE`, `GLORY_SEQUENCE`, ...)
+- [pillar-maturity-contracts.ts](../../../src/lib/types/pillar-maturity-contracts.ts) — contrats INTAKE/ENRICHED/COMPLETE
+- [auto-filler.ts](../../../src/server/services/pillar-maturity/auto-filler.ts) — moteur de complétion auto
+- [question-bank.ts](../../../src/server/services/quick-intake/question-bank.ts) — bank questions intake landing
+- [notoria.ts](../../../src/server/trpc/routers/notoria.ts) — router Notoria (mutations cascade)
+- [NEFER.md §3](../NEFER.md) — interdit #1 "Réinventer la roue" + interdit #3 "Drift narratif silencieux"
+- v6.1.18 — fix `rtis-cascade.savePillar` cache reconciliation (préalable indispensable à cet ADR)

--- a/docs/governance/adr/0031-notification-feed-bridge.md
+++ b/docs/governance/adr/0031-notification-feed-bridge.md
@@ -1,0 +1,79 @@
+# ADR-0031 — Feed Signal → Notification bridge (Anubis feed-bridge)
+
+**Date** : 2026-05-03
+**Statut** : Accepted
+**Phase** : 16 (extension ADR-0025)
+**Auteur direction** : opérateur (user)
+
+## Contexte
+
+Phase 16 (ADR-0025) a livré la stack notification temps-réel : `Notification` model + NSP broker SSE + bell UI + dropdown + Web Push + digest scheduler + quiet hours. Stack techniquement saine.
+
+Diagnostic NEFER 2026-05-03 : la stack est **branchée à du vide**. `grep "anubis.pushNotification" src/` retourne **un seul hit**, dans `notification.testPush` (admin manual test). Aucun service métier n'alimente la cloche.
+
+Conséquences en prod :
+
+1. **Notoria** termine un `generateBatch()` → écrit un `Signal` type `NOTORIA_BATCH_READY` direct en DB ([src/server/services/notoria/engine.ts:521](../../src/server/services/notoria/engine.ts:521)) → mais aucune `Notification` row n'est créée. Le founder ne sait pas que ses 12 recos sont prêtes.
+2. **Tarsis** détecte un weak signal urgency HIGH/CRITICAL → écrit un `Signal` type `WEAK_SIGNAL_ALERT` ([src/server/services/seshat/tarsis/weak-signal-analyzer.ts:152](../../src/server/services/seshat/tarsis/weak-signal-analyzer.ts:152)) → la cloche reste muette même quand un événement marché menace la marque.
+3. **Jehuty** est un service de lecture pure — il agrège `Signal` + `Reco` + `Diagnostic` en `JehutyFeedItem` pour `/cockpit/brand/jehuty`. Il ne peut pas être le point de hook puisqu'il ne reçoit aucun event d'écriture. Le hook doit se faire au moment de la production des signaux, en amont du feed.
+
+Drift typique post-Phase : feature shipped, consumers absents.
+
+## Décision
+
+**Pont centralisé `notifyOnFeedSignal()`** dans `src/server/services/anubis/feed-bridge.ts`, branché sur les producteurs de Signal qui alimentent le feed Jehuty. Le pont est un **wrapper non-bloquant** par-dessus `anubis.pushNotification()` qui :
+
+1. **Filtre** par type de signal (whitelist `FEED_SIGNAL_TYPES` : `WEAK_SIGNAL_ALERT`, `MARKET_SIGNAL`, `NOTORIA_BATCH_READY`, `STRONG`, `WEAK`, `METRIC`, `SCORE_IMPROVEMENT`, `SCORE_DECLINE`).
+2. **Mappe priorité** automatiquement par type (`WEAK_SIGNAL_ALERT → HIGH`, `NOTORIA_BATCH_READY → NORMAL`, `SCORE_DECLINE → HIGH`, etc.). Override `priority` paramétrable pour les cas critiques (Tarsis CRITICAL).
+3. **Résout les destinataires** depuis `Strategy.userId` (le founder owner). MVP intentionnellement minimal — voir §Étapes futures.
+4. **Push via `anubis.pushNotification()`** qui gère lui-même quiet hours, NotificationPreference, NSP publish (real-time SSE), et Web Push (deferred si pas de creds VAPID).
+5. **Swallow errors** — la création du Signal upstream ne doit jamais casser parce que la notif foire.
+
+## Surfaces touchées (cette PR)
+
+| Site producer | Avant | Après |
+|---|---|---|
+| `notoria/engine.ts:521` (NOTORIA_BATCH_READY) | `db.signal.create()` puis silence | `db.signal.create()` + `notifyOnFeedSignal()` avec link `/cockpit/notoria?batch=<id>` |
+| `seshat/tarsis/weak-signal-analyzer.ts:152` (WEAK_SIGNAL_ALERT urgency HIGH/CRITICAL) | `db.signal.create()` puis silence | `db.signal.create()` + `notifyOnFeedSignal()` × `[strategyId, ...affectedStrategyIds]` (cross-brand spread propagé) |
+
+## Décisions explicitement rejetées
+
+- **Brancher au router Jehuty** (`feed` query) — rejeté : Jehuty est lecture pure, le moment où un signal "arrive" pour le user n'est pas une query, c'est l'écriture upstream. Hook au mauvais endroit = invariant brisé.
+- **Émettre un Intent `ANUBIS_PUSH_NOTIFICATION` via `mestor.emitIntent()` à chaque Signal** — rejeté : surcharge governance pour un side-effect informatif. La notification suit le Signal, elle ne décide rien. `pushNotification()` reste un side-effect documenté dans le manifest Anubis (`sideEffects: ["DB_WRITE", "EXTERNAL_API", "EVENT_EMIT"]`) appelé en façade locale, comme `notification.testPush` le fait déjà.
+- **Notifier tous les Memberships du tenant** (UPgraders Console + founder) — reporté : MVP veut valider la boucle bell → click → page sur le founder en premier. Si UPgraders veulent leur cloche aussi, étendre `recipients` dans `feed-bridge.ts` (1 ligne, requête `Membership` par `tenantId`).
+- **Brancher tous les 16 sites `db.signal.create()`** — partiel : seuls les sites où le signal est destiné à apparaître dans le feed Jehuty et a un destinataire user identifiable sont branchés cette PR. Les autres (`pr.ts`, `mission.ts`, `media-buying.ts`, `quick-intake.ts`) sont des signaux internes ou liés à des entités sans user direct — étendre au cas par cas selon valeur produit.
+
+## Conséquences
+
+**Positif** :
+- Cloche topbar enfin vivante en prod : compteur unread monte sur events Notoria + Tarsis weak signals critiques.
+- Cross-brand propagation : un weak signal Tarsis qui affecte 5 brands déclenche 5 notifs (founder de chaque brand affectée).
+- NSP SSE event publié → bell UI invalide automatiquement `unreadCount` + `list` queries via `EventSource` listener.
+- Quiet hours respectées : un user en mode "ne pas déranger" voit la notif persistée en DB mais pas de push poussé.
+
+**Négatif / dette** :
+- UPgraders Console pas notifiés (TODO étendre `recipients`).
+- Pas de digest cadencé sur ces signaux : si Notoria génère 5 batches dans la journée → 5 notifs séparées. À reconsidérer si bruit signalé (re-router vers `anubis.runDigest()` daily).
+- Si `Strategy.userId` pointe vers un user inactif/supprimé, la notif part dans le vide silencieux.
+
+**Tests anti-drift** :
+- Aucun nouveau Neter, aucun nouveau model Prisma, aucune nouvelle entité métier.
+- Pas de nouvelle Capability (pas de modif manifest Anubis — `pushNotification` capability existante consommée en façade locale).
+- Cap APOGEE 7/7 maintenu.
+
+## Étapes futures
+
+1. **UPgraders notifier** — query `Membership` par `tenantId` pour étendre `recipients`. Granularité par rôle (admin/operator/viewer) si besoin.
+2. **Digest cadencé** — si volume Notoria dépasse 1 batch/jour/strategy, re-router vers digest scheduler `anubis.runDigest()` qui groupe les `FEED_SIGNAL` non lus en un email quotidien.
+3. **Branchement market-intelligence** — `signal-collector.ts:136` produit aussi des `MARKET_SIGNAL` → ajouter un appel `notifyOnFeedSignal()` (pattern identique).
+4. **In-app deep-link** — actuellement `/cockpit/brand/jehuty?signal=<id>`. Évaluer s'il faut une route dédiée par type (ex: `/cockpit/notoria?batch=<id>` déjà fait pour Notoria) ou un router générique `/cockpit/feed/[signalId]`.
+
+## Références
+
+- ADR-0011 — Anubis pré-réservé Comms
+- ADR-0020 — Anubis full activation Phase 15
+- ADR-0025 — Notification real-time stack (SSE + Web Push + templates + digest)
+- ADR-0026 — MCP bidirectionnel
+- [src/server/services/anubis/feed-bridge.ts](../../src/server/services/anubis/feed-bridge.ts) — implémentation
+- [src/server/services/notoria/engine.ts](../../src/server/services/notoria/engine.ts) — site #1
+- [src/server/services/seshat/tarsis/weak-signal-analyzer.ts](../../src/server/services/seshat/tarsis/weak-signal-analyzer.ts) — site #2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lafusee",
-  "version": "6.1.22",
+  "version": "6.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lafusee",
-      "version": "6.1.22",
+      "version": "6.1.23",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.74",
         "@ai-sdk/openai": "^3.0.58",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lafusee",
-  "version": "6.1.18",
+  "version": "6.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lafusee",
-      "version": "6.1.18",
+      "version": "6.1.19",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.74",
         "@ai-sdk/openai": "^3.0.58",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lafusee",
-  "version": "6.1.19",
+  "version": "6.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lafusee",
-      "version": "6.1.19",
+      "version": "6.1.22",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.74",
         "@ai-sdk/openai": "^3.0.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lafusee",
-  "version": "6.1.22",
+  "version": "6.1.23",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lafusee",
-  "version": "6.1.19",
+  "version": "6.1.22",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lafusee",
-  "version": "6.1.18",
+  "version": "6.1.19",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/(agency)/agency/layout.tsx
+++ b/src/app/(agency)/agency/layout.tsx
@@ -8,6 +8,8 @@
 
 import { AppShell, agencyNavGroups } from "@/components/navigation";
 import { Building2 } from "lucide-react";
+import { PortalWelcome } from "@/components/shared/portal-welcome";
+import { PortalTourHost } from "@/components/shared/portal-tour";
 
 function AgencySidebarHeader() {
   return (
@@ -43,6 +45,8 @@ export default function AgencyLayout({ children }: { children: React.ReactNode }
           </a>
         </footer>
       </AppShell>
+      <PortalWelcome portal="agency" />
+      <PortalTourHost portal="agency" />
     </div>
   );
 }

--- a/src/app/(cockpit)/cockpit/layout.tsx
+++ b/src/app/(cockpit)/cockpit/layout.tsx
@@ -5,6 +5,7 @@ import { Sparkles } from "lucide-react";
 import { StrategyProvider, useStrategy } from "@/components/cockpit/strategy-context";
 import { StrategySelector } from "@/components/cockpit/strategy-selector";
 import { PortalWelcome } from "@/components/shared/portal-welcome";
+import { PortalTourHost } from "@/components/shared/portal-tour";
 
 function CockpitSidebarHeader() {
   const { strategies, strategyId } = useStrategy();
@@ -41,6 +42,7 @@ export default function CockpitLayout({ children }: { children: React.ReactNode 
           {children}
         </AppShell>
         <PortalWelcome portal="cockpit" />
+        <PortalTourHost portal="cockpit" />
       </StrategyProvider>
     </div>
   );

--- a/src/app/(console)/console/layout.tsx
+++ b/src/app/(console)/console/layout.tsx
@@ -54,6 +54,8 @@
 
 import { AppShell, consoleNavGroups } from "@/components/navigation";
 import { Terminal } from "lucide-react";
+import { PortalWelcome } from "@/components/shared/portal-welcome";
+import { PortalTourHost } from "@/components/shared/portal-tour";
 
 function ConsoleSidebarHeader() {
   return (
@@ -80,6 +82,8 @@ export default function ConsoleLayout({ children }: { children: React.ReactNode 
       >
         {children}
       </AppShell>
+      <PortalWelcome portal="console" />
+      <PortalTourHost portal="console" />
     </div>
   );
 }

--- a/src/app/(creator)/creator/layout.tsx
+++ b/src/app/(creator)/creator/layout.tsx
@@ -3,6 +3,7 @@
 import { AppShell, creatorNavGroups } from "@/components/navigation";
 import { Shield } from "lucide-react";
 import { PortalWelcome } from "@/components/shared/portal-welcome";
+import { PortalTourHost } from "@/components/shared/portal-tour";
 
 function CreatorSidebarHeader() {
   return (
@@ -29,6 +30,7 @@ export default function CreatorLayout({ children }: { children: React.ReactNode 
         {children}
       </AppShell>
       <PortalWelcome portal="creator" />
+      <PortalTourHost portal="creator" />
     </div>
   );
 }

--- a/src/components/landing/marketing-footer.tsx
+++ b/src/components/landing/marketing-footer.tsx
@@ -42,7 +42,7 @@ export function MarketingFooter() {
       </div>
       <div className="mx-auto max-w-[var(--maxw-content)] px-[var(--pad-page)] mt-6 flex gap-6 font-mono text-[11px] text-foreground-muted flex-wrap">
         <span>UPgraders / La Fusée SARL — 2026</span>
-        <span>v6.1.19 · 2026-05-03</span>
+        <span>v6.1.22 · 2026-05-03</span>
         <span>Tous droits réservés.</span>
       </div>
     </footer>

--- a/src/components/landing/marketing-footer.tsx
+++ b/src/components/landing/marketing-footer.tsx
@@ -42,7 +42,7 @@ export function MarketingFooter() {
       </div>
       <div className="mx-auto max-w-[var(--maxw-content)] px-[var(--pad-page)] mt-6 flex gap-6 font-mono text-[11px] text-foreground-muted flex-wrap">
         <span>UPgraders / La Fusée SARL — 2026</span>
-        <span>v6.1.18 · 2026-05-03</span>
+        <span>v6.1.19 · 2026-05-03</span>
         <span>Tous droits réservés.</span>
       </div>
     </footer>

--- a/src/components/landing/marketing-footer.tsx
+++ b/src/components/landing/marketing-footer.tsx
@@ -42,7 +42,7 @@ export function MarketingFooter() {
       </div>
       <div className="mx-auto max-w-[var(--maxw-content)] px-[var(--pad-page)] mt-6 flex gap-6 font-mono text-[11px] text-foreground-muted flex-wrap">
         <span>UPgraders / La Fusée SARL — 2026</span>
-        <span>v6.1.22 · 2026-05-03</span>
+        <span>v6.1.23 · 2026-05-03</span>
         <span>Tous droits réservés.</span>
       </div>
     </footer>

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -63,6 +63,7 @@ export function Sidebar({ navGroups, portalAccentVar, headerContent }: SidebarPr
 
   return (
     <aside
+      data-tour-step="sidebar"
       className="sticky top-[var(--topbar-height)] flex h-[calc(100vh-var(--topbar-height))] shrink-0 flex-col overflow-visible border-r border-border-subtle bg-background-subtle transition-[width] duration-normal ease-out"
       style={{ width: collapsed ? "var(--sidebar-collapsed)" : "var(--sidebar-expanded)" }}
     >

--- a/src/components/navigation/topbar.tsx
+++ b/src/components/navigation/topbar.tsx
@@ -66,6 +66,7 @@ export function Topbar({
 
       {/* Center: Search trigger */}
       <button
+        data-tour-step="search"
         onClick={onOpenCommandPalette}
         className="mx-auto hidden items-center gap-2 rounded-lg border border-border-subtle bg-background-subtle px-3 py-1.5 text-sm text-foreground-muted transition-colors hover:border-border hover:text-foreground-secondary md:flex"
         aria-label="Ouvrir la recherche"
@@ -93,6 +94,7 @@ export function Topbar({
 
         {/* Mestor toggle */}
         <button
+          data-tour-step="mestor"
           onClick={onToggleMestor}
           className={`relative flex h-8 w-8 items-center justify-center rounded-md transition-colors ${
             mestorHasSuggestions

--- a/src/server/governance/__generated__/manifest-imports.ts
+++ b/src/server/governance/__generated__/manifest-imports.ts
@@ -8,12 +8,14 @@ import type { NeteruManifest } from "../manifest";
 import { manifest as advertisConnectorsManifest } from "@/server/services/advertis-connectors/manifest";
 import { manifest as advertisScorerManifest } from "@/server/services/advertis-scorer/manifest";
 import { manifest as aiCostTrackerManifest } from "@/server/services/ai-cost-tracker/manifest";
+import { manifest as anubisManifest } from "@/server/services/anubis/manifest";
 import { manifest as approvalWorkflowManifest } from "@/server/services/approval-workflow/manifest";
 import { manifest as artemisManifest } from "@/server/services/artemis/manifest";
 import { manifest as assetTaggerManifest } from "@/server/services/asset-tagger/manifest";
 import { manifest as auditTrailManifest } from "@/server/services/audit-trail/manifest";
 import { manifest as boardExportManifest } from "@/server/services/board-export/manifest";
 import { manifest as bootSequenceManifest } from "@/server/services/boot-sequence/manifest";
+import { manifest as brandVaultManifest } from "@/server/services/brand-vault/manifest";
 import { manifest as briefIngestManifest } from "@/server/services/brief-ingest/manifest";
 import { manifest as budgetAllocatorManifest } from "@/server/services/budget-allocator/manifest";
 import { manifest as campaignBudgetEngineManifest } from "@/server/services/campaign-budget-engine/manifest";
@@ -32,6 +34,7 @@ import { manifest as diagnosticEngineManifest } from "@/server/services/diagnost
 import { manifest as driverEngineManifest } from "@/server/services/driver-engine/manifest";
 import { manifest as ecosystemEngineManifest } from "@/server/services/ecosystem-engine/manifest";
 import { manifest as emailManifest } from "@/server/services/email/manifest";
+import { manifest as errorVaultManifest } from "@/server/services/error-vault/manifest";
 import { manifest as feedbackLoopManifest } from "@/server/services/feedback-loop/manifest";
 import { manifest as feedbackProcessorManifest } from "@/server/services/feedback-processor/manifest";
 import { manifest as financialBrainManifest } from "@/server/services/financial-brain/manifest";
@@ -40,6 +43,7 @@ import { manifest as financialReconciliationManifest } from "@/server/services/f
 import { manifest as founderPsychologyManifest } from "@/server/services/founder-psychology/manifest";
 import { manifest as gloryToolsManifest } from "@/server/services/glory-tools/manifest";
 import { manifest as guidelinesRendererManifest } from "@/server/services/guidelines-renderer/manifest";
+import { manifest as imhotepManifest } from "@/server/services/imhotep/manifest";
 import { manifest as implementationGeneratorManifest } from "@/server/services/implementation-generator/manifest";
 import { manifest as ingestionPipelineManifest } from "@/server/services/ingestion-pipeline/manifest";
 import { manifest as jehutyManifest } from "@/server/services/jehuty/manifest";
@@ -57,6 +61,7 @@ import { manifest as modelPolicyManifest } from "@/server/services/model-policy/
 import { manifest as monetizationManifest } from "@/server/services/monetization/manifest";
 import { manifest as neteruSharedManifest } from "@/server/services/neteru-shared/manifest";
 import { manifest as notoriaManifest } from "@/server/services/notoria/manifest";
+import { manifest as nspManifest } from "@/server/services/nsp/manifest";
 import { manifest as oauthIntegrationsManifest } from "@/server/services/oauth-integrations/manifest";
 import { manifest as operatorIsolationManifest } from "@/server/services/operator-isolation/manifest";
 import { manifest as paymentProvidersManifest } from "@/server/services/payment-providers/manifest";
@@ -68,15 +73,19 @@ import { manifest as pipelineOrchestratorManifest } from "@/server/services/pipe
 import { manifest as playbookCapitalizationManifest } from "@/server/services/playbook-capitalization/manifest";
 import { manifest as processSchedulerManifest } from "@/server/services/process-scheduler/manifest";
 import { manifest as promptRegistryManifest } from "@/server/services/prompt-registry/manifest";
+import { manifest as ptahManifest } from "@/server/services/ptah/manifest";
 import { manifest as qcRouterManifest } from "@/server/services/qc-router/manifest";
 import { manifest as quickIntakeManifest } from "@/server/services/quick-intake/manifest";
 import { manifest as rtisProtocolsManifest } from "@/server/services/rtis-protocols/manifest";
 import { manifest as sectorIntelligenceManifest } from "@/server/services/sector-intelligence/manifest";
+import { manifest as sentinelHandlersManifest } from "@/server/services/sentinel-handlers/manifest";
 import { manifest as sequenceVaultManifest } from "@/server/services/sequence-vault/manifest";
 import { manifest as seshatManifest } from "@/server/services/seshat/manifest";
 import { manifest as seshatBridgeManifest } from "@/server/services/seshat-bridge/manifest";
 import { manifest as slaTrackerManifest } from "@/server/services/sla-tracker/manifest";
+import { manifest as sourceClassifierManifest } from "@/server/services/source-classifier/manifest";
 import { manifest as stalenessPropagatorManifest } from "@/server/services/staleness-propagator/manifest";
+import { manifest as strategyArchiveManifest } from "@/server/services/strategy-archive/manifest";
 import { manifest as strategyPresentationManifest } from "@/server/services/strategy-presentation/manifest";
 import { manifest as talentEngineManifest } from "@/server/services/talent-engine/manifest";
 import { manifest as teamAllocatorManifest } from "@/server/services/team-allocator/manifest";
@@ -90,12 +99,14 @@ export const MANIFESTS: readonly NeteruManifest[] = [
   advertisConnectorsManifest,
   advertisScorerManifest,
   aiCostTrackerManifest,
+  anubisManifest,
   approvalWorkflowManifest,
   artemisManifest,
   assetTaggerManifest,
   auditTrailManifest,
   boardExportManifest,
   bootSequenceManifest,
+  brandVaultManifest,
   briefIngestManifest,
   budgetAllocatorManifest,
   campaignBudgetEngineManifest,
@@ -114,6 +125,7 @@ export const MANIFESTS: readonly NeteruManifest[] = [
   driverEngineManifest,
   ecosystemEngineManifest,
   emailManifest,
+  errorVaultManifest,
   feedbackLoopManifest,
   feedbackProcessorManifest,
   financialBrainManifest,
@@ -122,6 +134,7 @@ export const MANIFESTS: readonly NeteruManifest[] = [
   founderPsychologyManifest,
   gloryToolsManifest,
   guidelinesRendererManifest,
+  imhotepManifest,
   implementationGeneratorManifest,
   ingestionPipelineManifest,
   jehutyManifest,
@@ -139,6 +152,7 @@ export const MANIFESTS: readonly NeteruManifest[] = [
   monetizationManifest,
   neteruSharedManifest,
   notoriaManifest,
+  nspManifest,
   oauthIntegrationsManifest,
   operatorIsolationManifest,
   paymentProvidersManifest,
@@ -150,15 +164,19 @@ export const MANIFESTS: readonly NeteruManifest[] = [
   playbookCapitalizationManifest,
   processSchedulerManifest,
   promptRegistryManifest,
+  ptahManifest,
   qcRouterManifest,
   quickIntakeManifest,
   rtisProtocolsManifest,
   sectorIntelligenceManifest,
+  sentinelHandlersManifest,
   sequenceVaultManifest,
   seshatManifest,
   seshatBridgeManifest,
   slaTrackerManifest,
+  sourceClassifierManifest,
   stalenessPropagatorManifest,
+  strategyArchiveManifest,
   strategyPresentationManifest,
   talentEngineManifest,
   teamAllocatorManifest,

--- a/src/server/services/anubis/feed-bridge.ts
+++ b/src/server/services/anubis/feed-bridge.ts
@@ -1,0 +1,111 @@
+/**
+ * Anubis — Feed Signal → Notification bridge (ADR-0031).
+ *
+ * Pont entre les producteurs de Signal (Notoria batches, Tarsis weak signals,
+ * market-intelligence) et le notification center. Quand un Signal de type
+ * "feed" est créé en DB, ce helper push une `Notification` au(x) destinataire(s)
+ * via {@link pushNotification}, ce qui allume la cloche du topbar et publie
+ * un event NSP temps réel.
+ *
+ * Phase 16 (ADR-0025) avait posé la stack push (Notification model + NSP
+ * broker + SSE stream + bell UI), mais aucun service métier ne s'y branchait.
+ * Ce module ferme la boucle.
+ *
+ * **Destinataire MVP** : `Strategy.userId` (le founder qui possède la marque).
+ * Étendre vers les UPgraders Console (operatorId → users) dans un sprint
+ * ultérieur si la demande émerge.
+ *
+ * Failure mode : non-bloquant. La création du Signal réussit même si la
+ * notif échoue — on ne veut pas qu'un bug du notification center casse
+ * Notoria ou Tarsis.
+ */
+
+import { db } from "@/lib/db";
+import { pushNotification } from "./notifications";
+
+type FeedSignalPriority = "LOW" | "NORMAL" | "HIGH" | "CRITICAL";
+
+const PRIORITY_BY_SIGNAL: Record<string, FeedSignalPriority> = {
+  WEAK_SIGNAL_ALERT: "HIGH",
+  MARKET_SIGNAL: "NORMAL",
+  NOTORIA_BATCH_READY: "NORMAL",
+  STRONG: "HIGH",
+  WEAK: "LOW",
+  METRIC: "LOW",
+  SCORE_IMPROVEMENT: "NORMAL",
+  SCORE_DECLINE: "HIGH",
+};
+
+const FEED_SIGNAL_TYPES = new Set(Object.keys(PRIORITY_BY_SIGNAL));
+
+export interface NotifyOnFeedSignalArgs {
+  signalId: string;
+  signalType: string;
+  strategyId: string;
+  title: string;
+  body: string;
+  /** Default: /cockpit/brand/jehuty?signal=<signalId> */
+  link?: string;
+  /** Override the auto-mapped priority. */
+  priority?: FeedSignalPriority;
+}
+
+export interface NotifyOnFeedSignalResult {
+  status: "DELIVERED" | "SKIPPED_UNKNOWN_TYPE" | "SKIPPED_NO_STRATEGY" | "SKIPPED_NO_RECIPIENT";
+  notifiedUserIds: string[];
+}
+
+export async function notifyOnFeedSignal(
+  args: NotifyOnFeedSignalArgs,
+): Promise<NotifyOnFeedSignalResult> {
+  if (!FEED_SIGNAL_TYPES.has(args.signalType)) {
+    return { status: "SKIPPED_UNKNOWN_TYPE", notifiedUserIds: [] };
+  }
+
+  const strategy = await db.strategy.findUnique({
+    where: { id: args.strategyId },
+    select: { userId: true },
+  });
+
+  if (!strategy) {
+    return { status: "SKIPPED_NO_STRATEGY", notifiedUserIds: [] };
+  }
+
+  const recipients = new Set<string>();
+  if (strategy.userId) recipients.add(strategy.userId);
+
+  if (recipients.size === 0) {
+    return { status: "SKIPPED_NO_RECIPIENT", notifiedUserIds: [] };
+  }
+
+  const priority = args.priority ?? PRIORITY_BY_SIGNAL[args.signalType] ?? "NORMAL";
+  const link = args.link ?? `/cockpit/brand/jehuty?signal=${args.signalId}`;
+
+  const notified: string[] = [];
+  await Promise.allSettled(
+    Array.from(recipients).map(async (userId) => {
+      try {
+        await pushNotification({
+          userId,
+          type: "FEED_SIGNAL",
+          priority,
+          title: args.title,
+          body: args.body,
+          link,
+          entityType: "Signal",
+          entityId: args.signalId,
+          metadata: {
+            signalType: args.signalType,
+            strategyId: args.strategyId,
+          },
+          channels: ["IN_APP"],
+        });
+        notified.push(userId);
+      } catch {
+        /* non-blocking — feed signal creation must succeed even if notif fails */
+      }
+    }),
+  );
+
+  return { status: "DELIVERED", notifiedUserIds: notified };
+}

--- a/src/server/services/anubis/index.ts
+++ b/src/server/services/anubis/index.ts
@@ -55,6 +55,11 @@ export {
 export { renderTemplate, TemplateNotFoundError } from "./templates";
 export { runDigest } from "./digest-scheduler";
 export {
+  notifyOnFeedSignal,
+  type NotifyOnFeedSignalArgs,
+  type NotifyOnFeedSignalResult,
+} from "./feed-bridge";
+export {
   invokeExternalTool as mcpInvokeTool,
   syncRegistry as mcpSyncRegistry,
   registerServer as mcpRegisterServer,

--- a/src/server/services/brand-vault/manifest.ts
+++ b/src/server/services/brand-vault/manifest.ts
@@ -1,0 +1,156 @@
+/**
+ * Manifest — brand-vault (BrandAsset CRUD engine, Phase 10 ADR-0012).
+ *
+ * Vault unifié pour tous les actifs de marque (intellectuels + matériels).
+ * State machine DRAFT → CANDIDATE → SELECTED → ACTIVE → SUPERSEDED → ARCHIVED
+ * avec lineage hash-chain via IntentEmission.
+ *
+ * Sous tutelle MESTOR — toute mutation respecte LOI 1 (point unique de mutation
+ * via Intent kinds CREATE_BRAND_ASSET / SELECT_BRAND_ASSET / SUPERSEDE_BRAND_ASSET
+ * traités par mestor.commandant). Les capabilities listées ici sont les helpers
+ * de bas niveau exposés aux handlers Mestor + Ptah pour matérialisation post-forge.
+ */
+import { z } from "zod";
+import { defineManifest } from "@/server/governance/manifest";
+
+const StringId = z.string().min(1);
+
+const PillarSourceEnum = z.enum(["A", "D", "V", "E", "R", "T", "I", "S"]);
+const ManipulationModeEnum = z.enum(["peddler", "dealer", "facilitator", "entertainer"]);
+const FamilyEnum = z.enum(["INTELLECTUAL", "MATERIAL", "HYBRID"]);
+
+const CreateBrandAssetInput = z.object({
+  strategyId: StringId,
+  operatorId: StringId,
+  name: z.string().min(1),
+  kind: z.string().min(1),
+  format: z.string().optional(),
+  family: FamilyEnum.optional(),
+  content: z.record(z.string(), z.unknown()).optional(),
+  fileUrl: z.string().optional(),
+  mimeType: z.string().optional(),
+  fileSize: z.number().int().nonnegative().optional(),
+  summary: z.string().optional(),
+  pillarSource: PillarSourceEnum.optional(),
+  manipulationMode: ManipulationModeEnum.optional(),
+  state: z.string().optional(),
+  sourceIntentId: z.string().optional(),
+  sourceGloryOutputId: z.string().optional(),
+  sourceAssetVersionId: z.string().optional(),
+  sourceExecutionId: z.string().optional(),
+  batchId: z.string().optional(),
+  batchSize: z.number().int().positive().optional(),
+  batchIndex: z.number().int().nonnegative().optional(),
+  campaignId: z.string().optional(),
+  briefId: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+const BrandAssetOutput = z.object({
+  id: StringId,
+  strategyId: StringId,
+  kind: z.string(),
+  state: z.string(),
+}).passthrough();
+
+export const manifest = defineManifest({
+  service: "brand-vault",
+  governor: "MESTOR",
+  version: "1.0.0",
+  acceptsIntents: [],
+  emits: [],
+  capabilities: [
+    {
+      name: "createBrandAsset",
+      inputSchema: CreateBrandAssetInput,
+      outputSchema: BrandAssetOutput,
+      sideEffects: ["DB_WRITE"],
+      idempotent: false,
+      missionContribution: "DIRECT_BOTH",
+    },
+    {
+      name: "createCandidateBatch",
+      inputSchema: z.object({
+        strategyId: StringId,
+        operatorId: StringId,
+        kind: z.string().min(1),
+        format: z.string().optional(),
+        candidates: z.array(z.object({
+          name: z.string().min(1),
+          content: z.record(z.string(), z.unknown()).optional(),
+          summary: z.string().optional(),
+        })).min(1),
+        pillarSource: PillarSourceEnum.optional(),
+        manipulationMode: ManipulationModeEnum.optional(),
+        sourceIntentId: z.string().optional(),
+        sourceGloryOutputId: z.string().optional(),
+        sourceExecutionId: z.string().optional(),
+        campaignId: z.string().optional(),
+        briefId: z.string().optional(),
+      }),
+      outputSchema: z.object({
+        batchId: StringId,
+        candidates: z.array(BrandAssetOutput),
+      }),
+      sideEffects: ["DB_WRITE"],
+      idempotent: false,
+      missionContribution: "DIRECT_BOTH",
+    },
+    {
+      name: "selectFromBatch",
+      inputSchema: z.object({
+        batchId: StringId,
+        selectedAssetId: StringId,
+        selectedById: StringId,
+        selectedReason: z.string().optional(),
+        promoteToActive: z.boolean().optional(),
+      }),
+      outputSchema: BrandAssetOutput,
+      sideEffects: ["DB_WRITE", "EVENT_EMIT"],
+      idempotent: false,
+      missionContribution: "DIRECT_BOTH",
+    },
+    {
+      name: "promoteToActive",
+      inputSchema: z.object({
+        brandAssetId: StringId,
+        promotedById: StringId,
+      }),
+      outputSchema: BrandAssetOutput,
+      sideEffects: ["DB_WRITE"],
+      idempotent: true,
+      missionContribution: "DIRECT_BOTH",
+    },
+    {
+      name: "supersede",
+      inputSchema: z.object({
+        previousAssetId: StringId,
+        supersededById: StringId,
+        reason: z.string().optional(),
+      }),
+      outputSchema: BrandAssetOutput,
+      sideEffects: ["DB_WRITE"],
+      idempotent: true,
+      missionContribution: "DIRECT_BOTH",
+    },
+    {
+      name: "archive",
+      inputSchema: z.object({
+        brandAssetId: StringId,
+        archivedById: StringId,
+        reason: z.string().optional(),
+      }),
+      outputSchema: BrandAssetOutput,
+      sideEffects: ["DB_WRITE"],
+      idempotent: true,
+      missionContribution: "DIRECT_BOTH",
+    },
+  ],
+  dependencies: [],
+  docs: {
+    summary:
+      "Vault unifié BrandAsset (Phase 10, ADR-0012). State machine + lineage hash-chain + batch selection + supersession pour actifs intellectuels et matériels.",
+  },
+  missionContribution: "DIRECT_BOTH",
+  missionStep: 3,
+});

--- a/src/server/services/brand-vault/manifest.ts
+++ b/src/server/services/brand-vault/manifest.ts
@@ -12,10 +12,11 @@
  */
 import { z } from "zod";
 import { defineManifest } from "@/server/governance/manifest";
+import { PillarKeySchema } from "@/domain/pillars";
 
 const StringId = z.string().min(1);
 
-const PillarSourceEnum = z.enum(["A", "D", "V", "E", "R", "T", "I", "S"]);
+const PillarSourceEnum = PillarKeySchema;
 const ManipulationModeEnum = z.enum(["peddler", "dealer", "facilitator", "entertainer"]);
 const FamilyEnum = z.enum(["INTELLECTUAL", "MATERIAL", "HYBRID"]);
 

--- a/src/server/services/error-vault/manifest.ts
+++ b/src/server/services/error-vault/manifest.ts
@@ -1,0 +1,135 @@
+/**
+ * Manifest — error-vault (collecteur d'erreurs runtime centralisé, Phase 11).
+ *
+ * Capture serveur + client + Prisma + NSP + Ptah + stress-test + cron + webhook
+ * avec déduplication par signature sha256 (window 1h). Triage admin via
+ * /console/governance/error-vault.
+ *
+ * Sous tutelle SESHAT (observation runtime des erreurs comme weak signals système).
+ * Cf. ADR-0013, EXPERT-PROTOCOL.md.
+ */
+import { z } from "zod";
+import { defineManifest } from "@/server/governance/manifest";
+
+const StringId = z.string().min(1);
+
+const ErrorSourceEnum = z.enum([
+  "SERVER",
+  "CLIENT",
+  "PRISMA",
+  "NSP",
+  "PTAH",
+  "CRON",
+  "WEBHOOK",
+  "STRESS_TEST",
+  "TRPC",
+]);
+
+const ErrorSeverityEnum = z.enum(["DEBUG", "INFO", "WARN", "ERROR", "FATAL"]);
+
+const CaptureInput = z.object({
+  source: ErrorSourceEnum,
+  severity: ErrorSeverityEnum.optional(),
+  code: z.string().optional(),
+  message: z.string(),
+  stack: z.string().optional(),
+  route: z.string().optional(),
+  userId: z.string().optional(),
+  operatorId: z.string().optional(),
+  strategyId: z.string().optional(),
+  campaignId: z.string().optional(),
+  intentId: z.string().optional(),
+  trpcProcedure: z.string().optional(),
+  componentPath: z.string().optional(),
+  userAgent: z.string().optional(),
+  context: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const manifest = defineManifest({
+  service: "error-vault",
+  governor: "SESHAT",
+  version: "1.0.0",
+  acceptsIntents: [],
+  emits: [],
+  capabilities: [
+    {
+      name: "capture",
+      inputSchema: CaptureInput,
+      outputSchema: z.string().nullable(),
+      sideEffects: ["DB_WRITE"],
+      idempotent: true,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Sans collecteur d'erreurs runtime centralisé, les bugs Ptah/NSP/cron/Prisma passent silencieusement et dégradent la trajectoire APOGEE sans signal d'auto-correction. La déduplication par signature évite la noyade et permet le triage admin.",
+    },
+    {
+      name: "captureError",
+      inputSchema: z.object({
+        error: z.unknown(),
+        source: ErrorSourceEnum,
+        context: z.record(z.string(), z.unknown()).optional(),
+      }),
+      outputSchema: z.string().nullable(),
+      sideEffects: ["DB_WRITE"],
+      idempotent: true,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Wrapper typesafe pour capturer un Error/unknown depuis n'importe quel try/catch sans avoir à reconstruire le payload CaptureInput.",
+    },
+    {
+      name: "markResolved",
+      inputSchema: z.object({
+        errorId: StringId,
+        resolvedById: StringId,
+        resolution: z.string().optional(),
+      }),
+      outputSchema: z.object({ id: StringId, resolvedAt: z.date() }),
+      sideEffects: ["DB_WRITE"],
+      idempotent: true,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Triage admin nécessite une action explicite de résolution pour distinguer les erreurs traitées des oubliées. Sans markResolved, le vault devient un cimetière.",
+    },
+    {
+      name: "batchMarkResolved",
+      inputSchema: z.object({
+        errorIds: z.array(StringId).min(1),
+        resolvedById: StringId,
+        resolution: z.string().optional(),
+      }),
+      outputSchema: z.object({ count: z.number().int().nonnegative() }),
+      sideEffects: ["DB_WRITE"],
+      idempotent: true,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Batch resolve pour clusters d'erreurs (même signature × N occurrences) — sans cela le triage admin devient O(N) et inutilisable sur les vagues d'erreurs.",
+    },
+    {
+      name: "getStats",
+      inputSchema: z.object({
+        operatorId: z.string().optional(),
+        sinceHours: z.number().int().positive().optional(),
+      }),
+      outputSchema: z.object({
+        total: z.number().int().nonnegative(),
+        bySource: z.record(z.string(), z.number()),
+        bySeverity: z.record(z.string(), z.number()),
+        unresolved: z.number().int().nonnegative(),
+      }).passthrough(),
+      sideEffects: ["DB_READ"],
+      idempotent: true,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Stats agrégées pour dashboard admin et alerting — sans cela impossible de voir si un déploiement déclenche une régression.",
+    },
+  ],
+  dependencies: [],
+  docs: {
+    summary:
+      "Collecteur runtime errors (Phase 11). Dédup signature sha256 + triage admin /console/governance/error-vault. Best-effort capture (ne throw jamais pour éviter récursion infinie).",
+  },
+  missionContribution: "GROUND_INFRASTRUCTURE",
+  groundJustification:
+    "L'OS ne peut pas s'auto-corriger sans visibilité sur ses erreurs runtime ; sans error-vault, les bugs production-only restent invisibles et la trajectoire APOGEE dérive sans signal.",
+  missionStep: 4,
+});

--- a/src/server/services/notoria/engine.ts
+++ b/src/server/services/notoria/engine.ts
@@ -518,9 +518,13 @@ export async function generateBatch(
     recosByPillar,
   );
 
-  // ── Emit Signal for Jehuty / notification system ──
+  // ── Emit Signal for Jehuty feed + notify recipients via Anubis (ADR-0031) ──
   if (totalRecos > 0) {
-    await db.signal.create({
+    const targetPillars = [...recosByPillar.keys()];
+    const title = `Notoria: ${totalRecos} recommandation(s) ${missionType}`;
+    const content = `Batch ${missionType} genere avec ${totalRecos} recommandation(s) pour les piliers ${targetPillars.map(k => k.toUpperCase()).join(", ")}.`;
+
+    const signal = await db.signal.create({
       data: {
         strategyId,
         type: "NOTORIA_BATCH_READY",
@@ -529,14 +533,26 @@ export async function generateBatch(
           missionType,
           totalRecos,
           autoApplied,
-          targetPillars: [...recosByPillar.keys()],
-          title: `Notoria: ${totalRecos} recommandation(s) ${missionType}`,
-          content: `Batch ${missionType} genere avec ${totalRecos} recommandation(s) pour les piliers ${[...recosByPillar.keys()].map(k => k.toUpperCase()).join(", ")}.`,
+          targetPillars,
+          title,
+          content,
           urgency: "SOON",
           severity: "info",
         },
       },
-    }).catch(() => { /* non-blocking — signal is informational */ });
+    }).catch(() => null);
+
+    if (signal) {
+      const { notifyOnFeedSignal } = await import("@/server/services/anubis/feed-bridge");
+      await notifyOnFeedSignal({
+        signalId: signal.id,
+        signalType: "NOTORIA_BATCH_READY",
+        strategyId,
+        title,
+        body: content,
+        link: `/cockpit/notoria?batch=${batchId}`,
+      }).catch(() => { /* non-blocking — feed-bridge swallows its own errors */ });
+    }
   }
 
   return {

--- a/src/server/services/nsp/manifest.ts
+++ b/src/server/services/nsp/manifest.ts
@@ -1,0 +1,53 @@
+/**
+ * Manifest — nsp (Neteru Streaming Protocol — pure transport utility).
+ *
+ * **Pas une capability métier** — utilitaire pur publish/subscribe SSE pour
+ * streamer des événements (Intent progress, notifications, MCP invocations)
+ * vers les UIs connectées. Ne traite pas d'Intent, ne gère pas d'état métier.
+ *
+ * Manifest minimal présent pour permettre aux services métier (anubis, etc.)
+ * de déclarer `nsp` comme dépendance sans casser l'audit registry. ADR-0025
+ * (notification real-time stack).
+ *
+ * Sous tutelle INFRASTRUCTURE — transport infra transversale, pas de Neter
+ * gouverneur métier.
+ */
+import { z } from "zod";
+import { defineManifest } from "@/server/governance/manifest";
+
+const StringId = z.string().min(1);
+
+export const manifest = defineManifest({
+  service: "nsp",
+  governor: "INFRASTRUCTURE",
+  version: "1.0.0",
+  acceptsIntents: [],
+  emits: [],
+  capabilities: [
+    {
+      name: "publish",
+      inputSchema: z.object({
+        userId: StringId,
+        event: z.unknown(),
+      }),
+      outputSchema: z.object({
+        delivered: z.number().int().nonnegative(),
+      }),
+      sideEffects: ["EVENT_EMIT"],
+      idempotent: false,
+      latencyBudgetMs: 50,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Sans transport SSE temps réel, les UIs Cockpit/Console/Creator restent muettes pendant les Intents long-running (Ptah forge, sequences Glory) — l'opérateur navigue à l'aveugle et la perception de l'OS comme système vivant s'effondre.",
+    },
+  ],
+  dependencies: [],
+  docs: {
+    summary:
+      "Transport publish/subscribe SSE pour streamer Intent progress + notifications + MCP invocations vers UIs. Utilitaire pur, pas de capability métier. ADR-0025/0026.",
+  },
+  missionContribution: "GROUND_INFRASTRUCTURE",
+  groundJustification:
+    "Backbone temps réel de tout l'OS — sans NSP, aucun streaming UI possible et l'expérience devient batch/refresh manuel.",
+  missionStep: 4,
+});

--- a/src/server/services/sentinel-handlers/manifest.ts
+++ b/src/server/services/sentinel-handlers/manifest.ts
@@ -1,0 +1,57 @@
+/**
+ * Manifest — sentinel-handlers (Phase 9-suite résidu, Loi 4 maintien orbite).
+ *
+ * Consomme les `IntentEmission` rows en status=PENDING émises par le cron
+ * `/api/cron/sentinels` et exécute le travail réel pour chaque kind sentinel
+ * (MAINTAIN_APOGEE, DEFEND_OVERTON, EXPAND_TO_ADJACENT_SECTOR).
+ *
+ * Sous tutelle MESTOR — les Intent kinds eux-mêmes sont owned par mestor/seshat
+ * (cf. intent-kinds.ts). Ce service est un job batch idempotent qui draine la
+ * queue, pas un destinataire d'Intents direct.
+ *
+ * Téléologie : sans ces handlers, les sentinels émis sont invisibles — pas
+ * d'auto-correction APOGEE Loi 1+2, pas de Defense Overton Loi 4.
+ */
+import { z } from "zod";
+import { defineManifest } from "@/server/governance/manifest";
+
+const StringId = z.string().min(1);
+
+const SentinelRunResultSchema = z.object({
+  scanned: z.number().int().nonnegative(),
+  processed: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  byKind: z.record(z.string(), z.number()),
+  errors: z.array(z.object({
+    id: StringId,
+    kind: z.string(),
+    error: z.string(),
+  })),
+  durationMs: z.number().int().nonnegative(),
+});
+
+export const manifest = defineManifest({
+  service: "sentinel-handlers",
+  governor: "MESTOR",
+  version: "1.0.0",
+  acceptsIntents: [],
+  emits: ["CULT_TIER_REVIEW", "OVERTON_COUNTERMOVE_DETECTED"],
+  capabilities: [
+    {
+      name: "processPendingSentinels",
+      inputSchema: z.object({}),
+      outputSchema: SentinelRunResultSchema,
+      sideEffects: ["DB_READ", "DB_WRITE", "EVENT_EMIT"],
+      idempotent: true,
+      latencyBudgetMs: 30000,
+      missionContribution: "DIRECT_BOTH",
+    },
+  ],
+  dependencies: ["seshat"],
+  docs: {
+    summary:
+      "Job batch cron qui draine les IntentEmission sentinels PENDING. Idempotent : ne re-traite que PENDING, marque OK/FAILED. Phase 9-suite Loi 4 maintien orbite ICONE.",
+  },
+  missionContribution: "DIRECT_BOTH",
+  missionStep: 5,
+});

--- a/src/server/services/seshat/tarsis/weak-signal-analyzer.ts
+++ b/src/server/services/seshat/tarsis/weak-signal-analyzer.ts
@@ -149,7 +149,7 @@ Format JSON strict — tableau de WeakSignal :
 
       // If high urgency, create an alert signal for the feedback loop
       if (ws.urgency === "HIGH" || ws.urgency === "CRITICAL") {
-        await db.signal.create({
+        const signal = await db.signal.create({
           data: {
             strategyId,
             type: "WEAK_SIGNAL_ALERT",
@@ -169,6 +169,24 @@ Format JSON strict — tableau de WeakSignal :
             })),
           },
         });
+
+        // Notify source strategy + cross-brand affected strategies (ADR-0031).
+        const { notifyOnFeedSignal } = await import("@/server/services/anubis/feed-bridge");
+        const title = `Signal faible ${ws.urgency.toLowerCase()} — ${ws.impactCategory}`;
+        const body = ws.brandImpact?.slice(0, 280) ?? ws.thesis.slice(0, 280);
+        const allStrategyIds = [strategyId, ...affectedStrategyIds];
+        await Promise.allSettled(
+          allStrategyIds.map((sid) =>
+            notifyOnFeedSignal({
+              signalId: signal.id,
+              signalType: "WEAK_SIGNAL_ALERT",
+              strategyId: sid,
+              title,
+              body,
+              priority: ws.urgency === "CRITICAL" ? "CRITICAL" : "HIGH",
+            }),
+          ),
+        );
       }
     }
 

--- a/src/server/services/strategy-archive/manifest.ts
+++ b/src/server/services/strategy-archive/manifest.ts
@@ -1,0 +1,105 @@
+/**
+ * Manifest — strategy-archive (2-phase soft archive + hard purge, ADR-0028).
+ *
+ * Phase 1 : Strategy.archivedAt = now (réversible, caché des queries default).
+ * Phase 2 : DELETE row + BFS cascade sur 30+ tables enfants via information_schema
+ *           FK discovery (irréversible, exige archive préalable anti-foot-gun).
+ *
+ * Sous tutelle MESTOR — les 3 mutations passent par Intent kinds gouvernés
+ * (OPERATOR_ARCHIVE_STRATEGY, OPERATOR_RESTORE_STRATEGY, OPERATOR_PURGE_ARCHIVED_STRATEGY).
+ * Refuse les Wakanda dummies (anti-foot-gun protection seed data).
+ */
+import { z } from "zod";
+import { defineManifest } from "@/server/governance/manifest";
+
+const StringId = z.string().min(1);
+
+const HandlerResult = z.object({
+  status: z.enum(["OK", "FAILED", "VETOED"]),
+  summary: z.string(),
+  tool: z.string(),
+  output: z.unknown(),
+  reason: z.string().optional(),
+  estimatedCost: z.object({
+    amount: z.number().nonnegative(),
+    currency: z.string(),
+  }),
+});
+
+export const manifest = defineManifest({
+  service: "strategy-archive",
+  governor: "MESTOR",
+  version: "1.0.0",
+  acceptsIntents: [
+    "OPERATOR_ARCHIVE_STRATEGY",
+    "OPERATOR_RESTORE_STRATEGY",
+    "OPERATOR_PURGE_ARCHIVED_STRATEGY",
+  ],
+  emits: [],
+  capabilities: [
+    {
+      name: "archiveStrategyHandler",
+      inputSchema: z.object({
+        kind: z.literal("OPERATOR_ARCHIVE_STRATEGY"),
+        strategyId: StringId,
+      }).passthrough(),
+      outputSchema: HandlerResult,
+      sideEffects: ["DB_WRITE"],
+      idempotent: true,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Sans soft archive, les Strategies de tests/clients sortis polluent les requêtes opérateur ; la console devient illisible et bloque l'onboarding. Réversible = pas de risque d'erreur.",
+    },
+    {
+      name: "restoreStrategyHandler",
+      inputSchema: z.object({
+        kind: z.literal("OPERATOR_RESTORE_STRATEGY"),
+        strategyId: StringId,
+      }).passthrough(),
+      outputSchema: HandlerResult,
+      sideEffects: ["DB_WRITE"],
+      idempotent: true,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Réversibilité du soft archive : sans restore, l'archive devient une mort silencieuse — l'opérateur n'archive plus par peur. La possibilité de retour rend l'action sans risque.",
+    },
+    {
+      name: "purgeArchivedStrategyHandler",
+      inputSchema: z.object({
+        kind: z.literal("OPERATOR_PURGE_ARCHIVED_STRATEGY"),
+        strategyId: StringId,
+      }).passthrough(),
+      outputSchema: HandlerResult,
+      sideEffects: ["DB_WRITE"],
+      idempotent: false,
+      latencyBudgetMs: 30000,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Hard purge avec BFS cascade information_schema — sans cela, les Strategies abandonnées s'accumulent indéfiniment et la DB grossit sans bornes. Exige archive préalable (anti-foot-gun) pour éviter destruction accidentelle.",
+    },
+    {
+      name: "listArchivedStrategies",
+      inputSchema: z.object({
+        operatorId: z.string().nullable().optional(),
+      }),
+      outputSchema: z.array(z.object({
+        id: StringId,
+        archivedAt: z.date(),
+      }).passthrough()),
+      sideEffects: ["DB_READ"],
+      idempotent: true,
+      missionContribution: "GROUND_INFRASTRUCTURE",
+      groundJustification:
+        "Sans liste des archives, impossible de purger ou restaurer en connaissance de cause — l'opérateur navigue à l'aveugle.",
+    },
+  ],
+  dependencies: [],
+  docs: {
+    summary:
+      "2-phase soft archive (Strategy.archivedAt) + hard purge (BFS cascade information_schema FK discovery). 3 Intent kinds gouvernés MESTOR. Anti-foot-gun : purge exige archive préalable. Cf. ADR-0028.",
+  },
+  missionContribution: "GROUND_INFRASTRUCTURE",
+  groundJustification:
+    "Sans nettoyage Strategy lifecycle, la console se sature de Strategies tests/clients sortis ; la pipeline d'onboarding devient inutilisable et l'OS perd sa capacité opérationnelle.",
+  missionStep: 4,
+});


### PR DESCRIPTION
## Summary

Ferme la boucle laissée ouverte par Phase 16 (ADR-0025) : la stack notification temps-réel est enfin alimentée par les producteurs de Signal métier. Avant cette PR, le bell topbar était techniquement fonctionnel mais inerte en prod — Notoria et Tarsis écrivaient des `Signal` en DB sans jamais déclencher de `Notification` row, donc la cloche restait à zéro.

- **Helper `notifyOnFeedSignal()`** dans `src/server/services/anubis/feed-bridge.ts` — wrapper non-bloquant par-dessus `anubis.pushNotification()` qui filtre par whitelist FEED_SIGNAL_TYPES, mappe priorité auto, résout destinataires depuis `Strategy.userId`.
- **Notoria branché** (`engine.ts` après `db.signal.create({ type: "NOTORIA_BATCH_READY" })`) — link `/cockpit/notoria?batch=<id>`.
- **Tarsis branché** (`weak-signal-analyzer.ts` après `db.signal.create({ type: "WEAK_SIGNAL_ALERT" })`) — propagation cross-brand : un weak signal qui affecte 5 brands déclenche 5 notifs (founder de chaque brand affectée), priorité escaladée à CRITICAL si urgency = CRITICAL.

## Decisions rejetées (cf. ADR-0031)

- ❌ Hook au router Jehuty (lecture pure, mauvais point d'entrée)
- ❌ Intent `ANUBIS_PUSH_NOTIFICATION` via `mestor.emitIntent()` (overhead governance pour side-effect informatif — `pushNotification` reste façade locale comme `notification.testPush`)
- ❌ Notifier tous les Memberships du tenant MVP (reporté — étendre `recipients` plus tard)
- ❌ Brancher tous les 16 sites `db.signal.create()` (seuls Notoria + Tarsis HIGH/CRITICAL cette PR)

## Test plan

- [x] `npx tsc --noEmit` → 0 erreur introduite (6 erreurs résiduelles `.next/types/validator.ts` pré-existantes)
- [x] `npx tsx scripts/audit-neteru-narrative.ts` → 0 finding
- [x] `npx tsx scripts/audit-pantheon-completeness.ts` → 7/7 Neteru OK
- [x] `npx tsx scripts/audit-governance.ts` → 0 error / 217 warn (toutes pré-existantes)
- [ ] Smoke E2E : déclencher un batch Notoria → vérifier que la cloche topbar s'allume + dropdown affiche l'entry avec priority NORMAL + click ouvre `/cockpit/notoria?batch=<id>` (à faire en preview après merge)
- [ ] Smoke Tarsis : seed un weak signal HIGH → cloche s'allume avec priority HIGH + body = brandImpact slice 280

## Out of scope (étapes futures)

1. UPgraders Console notifier (étendre `recipients` via `Membership` lookup)
2. Digest cadencé si volume Notoria > 1 batch/jour/strategy → re-router vers `anubis.runDigest()`
3. Branchement `market-intelligence/signal-collector.ts:136` (MARKET_SIGNAL — pattern identique)

## Version

`v6.1.22 → v6.1.23` propagé dans `package.json`, `package-lock.json`, `marketing-footer.tsx`. Cap APOGEE 7/7 maintenu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)