### PR TITLE
chore(version): sync package.json to v6.18.5 + cleanup stale branches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lafusee",
-  "version": "6.1.34",
+  "version": "6.18.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lafusee",
-      "version": "6.1.34",
+      "version": "6.18.5",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.74",
         "@ai-sdk/openai": "^3.0.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lafusee",
-  "version": "6.1.34",
+  "version": "6.18.5",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

Audit des branches distantes : 5 branches restantes en plus de `main`. Toutes sont soit déjà mergées, soit squash-mergées, soit obsolètes.

| Branche | Status | Action |
|---|---|---|
| `docs/adr-0037-phase-17-deliverable-forge` | ✅ mergée | suppression |
| `feat/audit-makrea-cleanup-and-scoring-invariants` | ✅ squash-mergée (`3158b06`) | suppression |
| `phase/17-deliverable-forge-adr` | ✅ mergée | suppression |
| `feat/oracle-cascade-fixes-v6.17` | ⚠️ squash-mergée (`ba7d618`) | suppression |
| `chore/version-sync-v6.17.6` | ❌ obsolète (cible 6.17.6 dépassée) | **superseded par cette PR** + suppression |

**Vrai problème** : `package.json` était figé à `6.1.34` alors que CHANGELOG est à `v6.18.5`. La branche `chore/version-sync-v6.17.6` essayait de bumper à 6.17.6 mais a été dépassée par les squash-merges suivants. Je sync directement à v6.18.5.

## Changes

- `package.json` : `6.1.34` → `6.18.5`
- `package-lock.json` : sync identique

## Test plan

- [x] `git diff --stat` : 2 fichiers, 3 insertions / 3 suppressions
- [ ] Suppression des 5 branches obsolètes après merge

https://claude.ai/code/session_01EXXQ6qmUBBzFftsZiFJ9Ta

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXXQ6qmUBBzFftsZiFJ9Ta)_