### PR TITLE
test(boot-sequence): align mock with writePillarAndScore migration (7b91c35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 ---
 
 
+## v6.19.6 — Fix résidu test mock cache reconciliation : boot-sequence.test.ts (2026-05-06)
+
+**Résidu test laissé par commit `7b91c35` (cache reconciliation safe migrations, 8 callers `writePillar → writePillarAndScore`) : le mock `vi.mock("@/server/services/pillar-gateway", ...)` du test boot-sequence n'avait pas été propagé. 6/14 tests échouaient avec `[vitest] No "writePillarAndScore" export is defined on the "@/server/services/pillar-gateway" mock`. Fix : remplacement du mock obsolète `writePillar: vi.fn().mockResolvedValue({})` par `writePillarAndScore: vi.fn().mockResolvedValue({ success, version, previousContent, newContent, stalePropagated, warnings })` + 2 test cases mis à jour pour importer/référencer `writePillarAndScore`.**
+
+- `test(boot-sequence)` [tests/unit/services/boot-sequence.test.ts](tests/unit/services/boot-sequence.test.ts) — `writePillar` mock obsolète remplacé par `writePillarAndScore` retournant `PillarWriteResult` complet par défaut (interface canonique `src/server/services/pillar-gateway/index.ts:62`). Tests `"sauvegarde le pilier via writePillarAndScore"` et `"le step 2 sauvegarde le pilier 'v'"` mis à jour : import + variable mock renommés. Aligne le test avec `src/server/services/boot-sequence/index.ts:141` qui appelle `writePillarAndScore` depuis 7b91c35.
+- **Verify** : `npx vitest run tests/unit/services/boot-sequence.test.ts` → 14/14 passed (vs 8/14 avant). Non-régression élargie : 5 fichiers pillar/boot/mestor-related → 56/56 passed. Anti-drift CI (neteru-coherence + manipulation-coherence) → 21/21 passed.
+- **Résidu inchangé** : 40+ callers `writePillar` standalone subsistent dans `src/` (ai-filler, notoria, tarsis, hyperviseur, enrich-oracle, routers/pillar.ts, etc.) — déjà documenté dans v6.18.14 §"Cache reconciliation audit (23 callers `writePillar`)" + RESIDUAL-DEBT v6.1.18. Pattern canonique : swap `writePillar → writePillarAndScore` sauf cas explicites documentés.
+- **Versioning** : entry initialement v6.18.15 (post-rebase v6.19.6 — Phase 19 a bumpé le minor à v6.19.X entre-temps).
+
+---
+
+
 ## v6.19.5 — Phase 19 résidus zéro : migration SQL + Strategy.evaluatorMode + Anubis CRM API + Seshat tarsis API + Cluster B/E PRODUCTION + UI postmortem 12-step (2026-05-06)
 
 **Tous les résidus inférables Phase 19 résolus. Mandat utilisateur : DB env + business decisions + toucher Anubis/Seshat. Cluster B promu MVP→PRODUCTION via executeTool dispatch ; sous-clusters STUB tarsisBridge + stickiness promus → MVP via API Anubis CRM + Seshat tarsis ; Cluster E learnings cluster câblé Glory tools + extraction Q1-Q2-Q9-Q11 ; UI postmortem 12-step wizard shippée ; RBAC operatorProcedure câblé router economics ; migration SQL générée.**

--- a/tests/unit/services/boot-sequence.test.ts
+++ b/tests/unit/services/boot-sequence.test.ts
@@ -32,7 +32,14 @@ vi.mock("@/server/services/llm-gateway", () => ({
 
 // Mock pillar-gateway (used by advance via dynamic import)
 vi.mock("@/server/services/pillar-gateway", () => ({
-  writePillar: vi.fn().mockResolvedValue({}),
+  writePillarAndScore: vi.fn().mockResolvedValue({
+    success: true,
+    version: 1,
+    previousContent: {},
+    newContent: {},
+    stalePropagated: [],
+    warnings: [],
+  }),
 }));
 
 // Mock pillar-normalizer (used by complete via dynamic import)
@@ -127,14 +134,14 @@ describe("Boot Sequence", () => {
       expect(state.currentStep).toBe(1);
     });
 
-    it("sauvegarde le pilier via writePillar (pillar-gateway)", async () => {
-      const { writePillar } = await import("@/server/services/pillar-gateway");
-      const mockWritePillar = writePillar as ReturnType<typeof vi.fn>;
+    it("sauvegarde le pilier via writePillarAndScore (pillar-gateway)", async () => {
+      const { writePillarAndScore } = await import("@/server/services/pillar-gateway");
+      const mockWritePillarAndScore = writePillarAndScore as ReturnType<typeof vi.fn>;
 
       await advance("strat-1", 0, { q1: "valeur" });
 
-      expect(mockWritePillar).toHaveBeenCalledTimes(1);
-      const call = mockWritePillar.mock.calls[0]![0];
+      expect(mockWritePillarAndScore).toHaveBeenCalledTimes(1);
+      const call = mockWritePillarAndScore.mock.calls[0]![0];
       expect(call.strategyId).toBe("strat-1");
       expect(call.pillarKey).toBe("a"); // step 0 = pillar "a"
     });
@@ -159,12 +166,12 @@ describe("Boot Sequence", () => {
     });
 
     it("le step 2 sauvegarde le pilier 'v'", async () => {
-      const { writePillar } = await import("@/server/services/pillar-gateway");
-      const mockWritePillar = writePillar as ReturnType<typeof vi.fn>;
+      const { writePillarAndScore } = await import("@/server/services/pillar-gateway");
+      const mockWritePillarAndScore = writePillarAndScore as ReturnType<typeof vi.fn>;
 
       await advance("strat-1", 2, { pricing: "premium" });
 
-      const call = mockWritePillar.mock.calls[0]![0];
+      const call = mockWritePillarAndScore.mock.calls[0]![0];
       expect(call.pillarKey).toBe("v");
     });
   });


### PR DESCRIPTION
## Summary

Le commit `7b91c35` (cache reconciliation safe migrations, 8 callers `writePillar` → `writePillarAndScore`) a oublié de propager le mock du test `tests/unit/services/boot-sequence.test.ts`. Résultat : 6/14 tests échouaient avec `[vitest] No "writePillarAndScore" export is defined on the "@/server/services/pillar-gateway" mock`.

**Fix** : remplacement du mock obsolète `writePillar: vi.fn().mockResolvedValue({})` par `writePillarAndScore: vi.fn().mockResolvedValue(<PillarWriteResult>)` (interface canonique [src/server/services/pillar-gateway/index.ts:62](src/server/services/pillar-gateway/index.ts#L62)) + 2 test cases mis à jour.

## Test plan

- [x] `npx vitest run tests/unit/services/boot-sequence.test.ts` → **14/14 passed** (vs 8/14 avant)
- [x] Non-régression — 5 fichiers pillar/boot/mestor-related → **56/56 passed**
- [x] Anti-drift — `neteru-coherence` + `manipulation-coherence` → **21/21 passed**
- [x] CHANGELOG entry v6.18.15 ajoutée (NEFER Phase 6.0)
- [x] Husky pre-commit governance lint + audit-changelog-coverage → ✓

## Résidu signalé (déjà tracké)

40+ callers `writePillar` standalone subsistent dans `src/` (ai-filler, notoria, tarsis, hyperviseur, enrich-oracle, routers/pillar.ts, etc.) — déjà documenté dans :
- [RESIDUAL-DEBT.md v6.1.18](docs/governance/RESIDUAL-DEBT.md)
- [CHANGELOG v6.18.14 §"Cache reconciliation audit (23 callers writePillar)"](CHANGELOG.md)

Pattern canonique : swap `writePillar → writePillarAndScore` sauf cas explicites documentés (sprint dédié — décision per-caller, pas mass-migration).

## NEFER protocole exécuté

- ✅ Phase 0 — check préventif (7 sources de vérité chargées)
- ✅ Phase 1 — APOGEE Guidance/Mestor, Loi 1 conservation altitude
- ✅ Phase 2 — anti-doublon (1 seul mock obsolete dans tests/, autres mocks pillar/notoria/mestor non affectés)
- ✅ Phase 3-4 — exécution ciblée
- ✅ Phase 5 — 77 tests verts, 0 régression
- ✅ Phase 6 — CHANGELOG v6.18.15 ajoutée
- ✅ Phase 7 — commit explicit-staged Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)