### PR TITLE
fix(governance): NEFER fine-review CI 3 erreurs + 3 anti-récidives structurelles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+<!--
+  PR template — La Fusée governance.
+  Le CI exige UN label avant merge :
+  - phase/0 ... phase/9 (refonte structurelle)  OU
+  - out-of-scope         (cleanup hors-périmètre — ajouter section "Justification — out-of-scope")
+  Cf. docs/governance/REFACTOR-CODE-OF-CONDUCT.md §1.
+-->
+
+## Intent
+
+<!-- 1-3 phrases : pourquoi ce changement, quel problème ça résout. -->
+
+## Changes
+
+<!-- Liste concise. Lien vers ADR si décision structurelle. -->
+
+## Phase / Scope
+
+<!-- Cocher UNE ligne : -->
+- [ ] phase/0  — refonte governance / outillage
+- [ ] phase/1  — pillars + intent kinds
+- [ ] phase/2  — manifests + pre/post conditions
+- [ ] phase/3  — Mestor router + governed procedures
+- [ ] phase/4  — Seshat telemetry
+- [ ] phase/5  — Thot fuel + cost gate
+- [ ] phase/6  — UI + portail Console
+- [ ] phase/7  — Cockpit founders
+- [ ] phase/8  — Glory tools + sequences
+- [ ] phase/9  — Ptah Forge sub-phases A→K
+- [ ] out-of-scope (ajouter section "Justification — out-of-scope" ci-dessous)
+
+## Justification — out-of-scope
+
+<!-- Obligatoire si label `out-of-scope`. Sinon supprimer cette section. -->
+
+## Test plan
+
+- [ ] ...
+
+## Pre-merge checklist (NEFER protocole 8 phases)
+
+- [ ] Phase 0 — `git log` + 7 sources de vérité chargées
+- [ ] Phase 2 — `grep CODE-MAP.md` négatif (pas de doublon entité)
+- [ ] Phase 5 — typecheck + lint + tests verts en local
+- [ ] Phase 6 — CHANGELOG.md + ADR mis à jour si décision structurelle
+- [ ] Commits respectent Conventional Commits (`type(scope): subject`, body lines ≤100 chars)
+- [ ] PR a un label `phase/N` ou `out-of-scope` (le CI bloque sinon)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 ---
 
 
+## v6.19.9 — NEFER fine-review CI fixes + 3 anti-récidives structurelles (2026-05-07)
+
+**3 jobs CI rouges sur PR #78 (consolidation branches) corrigés. Pour chaque erreur, fix immédiat + anti-récidive structurelle pour qu'aucune PR future ne rencontre le même problème. Pas de skip de sécurité.**
+
+### Fix 1 — `Unit tests (vitest)` rouge — ✅ shipped
+
+- `fix(test)` [tests/unit/services/deliverable-orchestrator/vault-matcher.test.ts](tests/unit/services/deliverable-orchestrator/vault-matcher.test.ts) — pattern `findManyMock` top-level + `vi.mock()` factory provoquait `ReferenceError: Cannot access 'findManyMock' before initialization` (vi.mock hoistée avant les inits). Migré vers `vi.hoisted(() => ({ findManyMock: vi.fn() }))`.
+- `fix(test)` [tests/unit/services/deliverable-orchestrator/resolver.test.ts](tests/unit/services/deliverable-orchestrator/resolver.test.ts) — `require("@/.../resolver")` dynamique remplacé par `import { _internals }` ES6 (l'export existe déjà ligne 127 de resolver.ts).
+- **Anti-récidive** : nouvelle règle ESLint `lafusee/no-vi-mock-toplevel-var` (8e règle du plugin) — détecte `vi.mock(...)` dont la factory référence une variable top-level non-`vi.hoisted()`. Severity `error`. Activée dans `eslint.config.mjs`. Plugin bumped 0.3.0 → 0.4.0.
+
+### Fix 2 — `Phase label present (refonte)` rouge — ✅ shipped
+
+- Cause : PR #78 sans label `phase/N` ni `out-of-scope` requis par CI.
+- **Anti-récidive** : nouveau `.github/pull_request_template.md` — checklist label + commit-message format + Phase 5/6 NEFER. Tout PR future créée avec ce template aura le rappel visible.
+
+### Fix 3 — `Commit message lint` rouge — ✅ shipped
+
+- Cause : merge commit `c6013da` body avait 2 lignes >100 chars (186 et 188), violation `body-max-line-length: 100` config-conventional. Hook `.husky/commit-msg` skippé pendant le merge (corner case).
+- Fix : `git commit --amend` avec body reformulé, toutes lignes ≤77 chars.
+- **Anti-récidive** : NEFER.md §9 checklist Phase 7.2 enrichie — précision explicite "toutes lignes ≤100 chars (header + body)" + bloc "Format commit canonique" + warning sur le pattern récurrent merge-commit body trop long. Phase 7.4 ajoutée pour le rappel label PR.
+
+### Méta
+
+Cap APOGEE 7/7 préservé. Pas de Neter, pas de model Prisma. 100% governance + tooling.
+
 ## v6.19.8 — Méga sprint NEFER : XLSX parser binary + audit résidus (2026-05-07)
 
 **NEFER mégasprint autonome — fine-review post-merge sprint/9. 14 catégories de "pas shippé" auditées, 3 sprints exécutés en autonomie, 11 catégories correctement classées "skip avec rationale" (auto-promotion module, formulaire opérateur, ADRs enfants business). Pas de force-bypass des safety mechanisms ADR-0065 + ADR-0066 + NEFER doctrine §1.1.**

--- a/docs/governance/NEFER.md
+++ b/docs/governance/NEFER.md
@@ -697,10 +697,28 @@ Si NEFER se surprend à :
 - [ ] **Phase 6.2** — docs auto-régénérées (CODE-MAP, INTENT-CATALOG)
 - [ ] **Phase 6.3** — `missionContribution` déclaré
 - [ ] **Phase 7.1** — stager explicite (pas `-A`)
-- [ ] **Phase 7.2** — commit message Conventional Commits avec verify + résidus
+- [ ] **Phase 7.2** — commit message Conventional Commits **toutes lignes ≤100 chars** (header + body) avec verify + résidus
 - [ ] **Phase 7.3** — push + RESIDUAL-DEBT mis à jour si lessons learned
+- [ ] **Phase 7.4** — PR créée avec label `phase/N` ou `out-of-scope` (CI bloque sinon, cf. `.github/workflows/ci.yml` job `Phase label present`)
 
 **Si une seule case n'est pas cochée → ne pas committer.**
+
+**Format commit canonique** (commitlint config — `commitlint.config.cjs`) :
+
+```
+<type>(<scope>): <subject ≤100 chars>
+<ligne vide>
+<body line 1 ≤100 chars>
+<body line 2 ≤100 chars>
+...
+```
+
+- `type` ∈ `feat|fix|refactor|perf|docs|test|ci|chore|build|revert|governance` (enum strict)
+- `scope` ∈ liste `commitlint.config.cjs` (warning si hors-liste)
+- **`body-max-line-length: 100`** — lignes longues sont l'erreur la plus fréquente sur les merge-commits récapitulatifs
+- Hook `.husky/commit-msg` lance `commitlint --edit` automatiquement ; **ne jamais bypass avec `--no-verify`** sauf cas explicite (ex: amend de message d'un merge dans environnement sans `node_modules`).
+
+**Pattern récurrent de fail** : merge commit body qui détaille les branches skippées avec une ligne par branche → lignes >100 chars rapides. Solution : tirets courts + résumé concis, détails complets dans la PR body (qui n'a pas de limite).
 
 ### Checklist post-merge (§5 Phase 9 — après chaque merge sur main)
 

--- a/docs/governance/scope-drift.md
+++ b/docs/governance/scope-drift.md
@@ -17,3 +17,4 @@ The refonte fails its discipline target if this file grows by more than
 <!-- entries below this line -->
 
 | 2026-05-02 | #39 | feat(brand-portal) RAG sources + filtreur qualifiant | NEFER (batch merge) | Extension fonctionnelle post-Phase 15 — pas de nouveau Neter, pas de nouveau model Prisma, pas de bypass governance. ADR-0027 (renuméroté post-merge — collision 0023 avec OPERATOR_AMEND_PILLAR). Cf. Justification dans body PR. |
+| 2026-05-07 | #79 | fix(governance) NEFER fine-review CI 3 erreurs + 3 anti-récidives | NEFER (auto) | Tooling CI + tests pré-existants (vault-matcher/resolver bugs depuis 0fe1407). Cap APOGEE 7/7 préservé, aucun Neter, aucun model Prisma. Anti-récidives = ESLint rule lafusee/no-vi-mock-toplevel-var + PR template + NEFER.md Phase 7.2/7.4. |

--- a/eslint-plugin-lafusee/index.js
+++ b/eslint-plugin-lafusee/index.js
@@ -1,7 +1,7 @@
 /**
  * eslint-plugin-lafusee — governance lint rules.
  *
- * 7 rules. All registered as `lafusee/<name>`. Severities are configured by
+ * 8 rules. All registered as `lafusee/<name>`. Severities are configured by
  * the consumer (see `eslint.config.js`) — the rules themselves are neutral.
  */
 
@@ -14,11 +14,12 @@ const noNumberedDuplicates = require("./rules/no-numbered-duplicates");
 const noAdhocCompletionMath = require("./rules/no-adhoc-completion-math");
 const designTokenOnly = require("./rules/design-token-only");
 const noDirectLucideImport = require("./rules/no-direct-lucide-import");
+const noViMockToplevelVar = require("./rules/no-vi-mock-toplevel-var");
 
 module.exports = {
   meta: {
     name: "eslint-plugin-lafusee",
-    version: "0.3.0",
+    version: "0.4.0",
   },
   rules: {
     "no-direct-service-from-router": noDirectServiceFromRouter,
@@ -28,5 +29,6 @@ module.exports = {
     "no-adhoc-completion-math": noAdhocCompletionMath,
     "design-token-only": designTokenOnly,
     "no-direct-lucide-import": noDirectLucideImport,
+    "no-vi-mock-toplevel-var": noViMockToplevelVar,
   },
 };

--- a/eslint-plugin-lafusee/rules/no-vi-mock-toplevel-var.js
+++ b/eslint-plugin-lafusee/rules/no-vi-mock-toplevel-var.js
@@ -1,0 +1,109 @@
+/**
+ * lafusee/no-vi-mock-toplevel-var
+ *
+ * Interdit `vi.mock("...", () => ...)` dont la factory référence un binding
+ * déclaré au top-level (const/let/var) sans passer par `vi.hoisted(...)`.
+ *
+ * `vi.mock()` est hoistée par vitest avant les imports + initialisations top-level.
+ * Le binding référencé n'existe donc pas encore quand la factory s'exécute :
+ * `ReferenceError: Cannot access 'foo' before initialization`.
+ *
+ * Pattern correct :
+ *   const { foo } = vi.hoisted(() => ({ foo: vi.fn() }));
+ *   vi.mock("@/lib/x", () => ({ x: foo }));
+ *
+ * Pattern interdit :
+ *   const foo = vi.fn();                         // top-level binding
+ *   vi.mock("@/lib/x", () => ({ x: foo }));      // référence le binding → crash
+ */
+
+"use strict";
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid vi.mock() factories referencing top-level bindings not declared via vi.hoisted()",
+      category: "Possible Errors",
+    },
+    schema: [],
+    messages: {
+      ref: "vi.mock() factory references top-level binding '{{name}}' which is not vi.hoisted(). " +
+        "Wrap the binding: const {{ {{name}} }} = vi.hoisted(() => ({ {{name}}: vi.fn() })); " +
+        "Otherwise vitest hoists vi.mock() before initialization → ReferenceError at runtime.",
+    },
+  },
+  create(context) {
+    const filename = context.filename || context.getFilename?.() || "";
+    if (!/\.test\.(ts|tsx|js|jsx|mjs|cjs)$/.test(filename)) return {};
+
+    /** Map<name, "hoisted" | "plain">. Top-level only. */
+    const topLevelBindings = new Map();
+
+    function isViHoistedCall(init) {
+      return (
+        init &&
+        init.type === "CallExpression" &&
+        init.callee.type === "MemberExpression" &&
+        init.callee.object.type === "Identifier" &&
+        init.callee.object.name === "vi" &&
+        init.callee.property.type === "Identifier" &&
+        init.callee.property.name === "hoisted"
+      );
+    }
+
+    function collectNames(idNode, isHoisted) {
+      if (!idNode) return;
+      if (idNode.type === "Identifier") {
+        topLevelBindings.set(idNode.name, isHoisted ? "hoisted" : "plain");
+      } else if (idNode.type === "ObjectPattern") {
+        for (const prop of idNode.properties) {
+          if (prop.type === "Property") collectNames(prop.value, isHoisted);
+          else if (prop.type === "RestElement") collectNames(prop.argument, isHoisted);
+        }
+      } else if (idNode.type === "ArrayPattern") {
+        for (const el of idNode.elements) collectNames(el, isHoisted);
+      }
+    }
+
+    function isViMockCall(node) {
+      return (
+        node.type === "CallExpression" &&
+        node.callee.type === "MemberExpression" &&
+        node.callee.object.type === "Identifier" &&
+        node.callee.object.name === "vi" &&
+        node.callee.property.type === "Identifier" &&
+        node.callee.property.name === "mock"
+      );
+    }
+
+    return {
+      Program(program) {
+        for (const stmt of program.body) {
+          if (stmt.type === "VariableDeclaration") {
+            for (const decl of stmt.declarations) {
+              const hoisted = isViHoistedCall(decl.init);
+              collectNames(decl.id, hoisted);
+            }
+          }
+        }
+      },
+      CallExpression(node) {
+        if (!isViMockCall(node)) return;
+        const factory = node.arguments[1];
+        if (!factory || (factory.type !== "ArrowFunctionExpression" && factory.type !== "FunctionExpression")) return;
+
+        const sourceCode = context.sourceCode || context.getSourceCode();
+        const factoryTokens = sourceCode.getTokens(factory);
+        for (const tok of factoryTokens) {
+          if (tok.type !== "Identifier") continue;
+          const kind = topLevelBindings.get(tok.value);
+          if (kind === "plain") {
+            context.report({ node: tok, messageId: "ref", data: { name: tok.value } });
+          }
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,6 +71,7 @@ export default [
       "lafusee/no-cross-portal-import": "warn",
       "lafusee/no-numbered-duplicates": "error",
       "lafusee/no-adhoc-completion-math": "warn",
+      "lafusee/no-vi-mock-toplevel-var": "error",
 
       // Layering — strict downward imports only. Severity is "warn" until
       // end-of-Phase-4, then escalates to "error" via the override above.

--- a/tests/unit/services/deliverable-orchestrator/resolver.test.ts
+++ b/tests/unit/services/deliverable-orchestrator/resolver.test.ts
@@ -3,6 +3,7 @@ import {
   resolveRequirements,
   extractUpstreamKinds,
   describeDag,
+  _internals,
 } from "@/server/services/deliverable-orchestrator/resolver";
 import {
   ResolverCycleDetectedError,
@@ -103,9 +104,6 @@ describe("deliverable-orchestrator/resolver", () => {
 
   describe("target-mapping coverage", () => {
     it("every supported target kind has a real Glory tool slug", () => {
-      // Sanity : les slugs déclarés dans la map existent dans le registry.
-      // (cette assertion casse si on rename un slug sans mettre à jour la map).
-      const { _internals } = require("@/server/services/deliverable-orchestrator/resolver");
       const known = new Set(_internals.EXTENDED_GLORY_TOOLS.map((t: { slug: string }) => t.slug));
       for (const slug of Object.values(TARGET_KIND_TO_PRODUCER_SLUG)) {
         expect(known.has(slug)).toBe(true);

--- a/tests/unit/services/deliverable-orchestrator/vault-matcher.test.ts
+++ b/tests/unit/services/deliverable-orchestrator/vault-matcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const findManyMock = vi.fn();
+const { findManyMock } = vi.hoisted(() => ({ findManyMock: vi.fn() }));
 
 vi.mock("@/lib/db", () => ({
   db: {


### PR DESCRIPTION
## Intent

PR #78 a été mergée avec **3 jobs CI rouges** (Commit message lint, Phase label, Unit tests). NEFER fine-review post-merge : fix immédiat des 3 + protections structurelles pour qu'aucune PR future ne rencontre les mêmes problèmes. Pas de skip de sécurité.

## Phase / Scope

Cette PR est `out-of-scope` (refonte governance / outillage CI sans business code).

## Justification — out-of-scope

Les 3 fixes touchent :
1. 2 fichiers de tests pré-existants (corrige des bugs vitest présents depuis le commit `0fe1407` qui introduisait `deliverable-orchestrator`).
2. Un nouveau plugin ESLint rule (anti-récidive structurelle).
3. Un PR template GitHub.
4. Un complément doc dans `NEFER.md` Phase 7.2/7.4.

Aucun changement de business logic, aucun nouveau Neter, aucun model Prisma. Cap APOGEE 7/7 préservé. Surface d'attaque limitée à : tests unitaires + tooling CI + docs.

## Changes

### Fix 1 — `Unit tests (vitest)` — bugs pré-existants `0fe1407`

| Fichier | Problème | Fix |
|---|---|---|
| `tests/unit/services/deliverable-orchestrator/vault-matcher.test.ts:3` | `findManyMock` top-level + `vi.mock()` factory → `ReferenceError: Cannot access 'findManyMock' before initialization` (vi.mock hoistée) | `vi.hoisted(() => ({ findManyMock: vi.fn() }))` |
| `tests/unit/services/deliverable-orchestrator/resolver.test.ts:108` | `require("@/.../resolver")` dynamique cassé en module ESM | `import { _internals }` ES6 (déjà exporté ligne 127 de `resolver.ts`) |

### Fix 2 — `Phase label present (refonte)` — manquant sur PR #78

Cause : aucun label `phase/N` ni `out-of-scope`. Cette PR ajoute le label `out-of-scope` + section justification ci-dessus.

### Fix 3 — `Commit message lint` — body lignes >100 chars

Cause : merge commit `c6013da` body avait 2 lignes (186 et 188 chars) violant `body-max-line-length: 100`. Corrigé par amend dans `fcb0335` (max 77 chars), puis le contenu a été directement mergé sur main par l'utilisateur via PR #78.

## Anti-récidive structurelle (3 protections nouvelles)

| Protection | Cible | Localisation |
|---|---|---|
| **ESLint rule `lafusee/no-vi-mock-toplevel-var`** (severity `error`) | Tout `vi.mock(...)` dont la factory référence une variable top-level non-`vi.hoisted()` est bloqué dès `npm run lint:governance`. Plugin `eslint-plugin-lafusee` bumped 0.3.0 → 0.4.0 (8e règle). | `eslint-plugin-lafusee/rules/no-vi-mock-toplevel-var.js` + activation `eslint.config.mjs` |
| **PR template** | Toute nouvelle PR aura une checklist visible : choix de label `phase/N` ou `out-of-scope`, section justification conditionnelle, rappel commit-message ≤100 chars. | `.github/pull_request_template.md` |
| **NEFER.md Phase 7.2/7.4 enrichies** | Précision explicite "toutes lignes ≤100 chars (header + body)" + bloc "Format commit canonique" + warning sur le pattern récurrent merge-commit body trop long. Phase 7.4 ajoutée pour le rappel label PR. | `docs/governance/NEFER.md` §9 |

CHANGELOG.md v6.19.8.

## Test plan

- [ ] CI verte sur cette PR (les 3 jobs précédemment rouges)
- [ ] Vérifier que `lafusee/no-vi-mock-toplevel-var` ne déclenche pas de faux positifs sur les tests existants (la règle ne s'applique qu'aux `*.test.{ts,tsx,js}`)
- [ ] Confirmer visuellement le PR template à la prochaine PR créée

## Provenance

NEFER protocole 8 phases — Phase 0 audit logs CI → Phase 2 grep husky/eslint/commitlint pour confirmer infrastructure → Phase 3 conception 3 fixes + 3 anti-récidives → Phase 5 vérification statique commit-line-length → Phase 6 CHANGELOG.md + NEFER.md mis à jour → Phase 7 commit avec format conforme → Phase 8 cette PR avec template auto-rappel.

Doctrine LLM §1.1 respectée : profondeur > raccourci. Pour chaque erreur, fix immédiat + cause racine + anti-récidive — pas seulement le symptôme.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMfcMMus4NjfkyMJmvUyTJ)_