### PR TITLE
fix(oracle): ordre blocs compilés + Imhotep/Anubis loader + Export PDF — v6.19.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 ---
 
 
+## v6.19.20 — Oracle blocs compilés ordre cohérent + Imhotep/Anubis loader fix + Export PDF route (2026-05-07)
+
+**3 bugs profonds Oracle identifiés et corrigés en mégasprint NEFER pendant test live Bliss (`wk-strategy-bliss`) :**
+
+### Bug #1 — Ordre incohérent SECTION_REGISTRY (visuel cockpit + Oracle render)
+Sections #34 Crew Program (Imhotep) et #35 Plan Comms (Anubis) étaient taggées `tier: "CORE"` mais positionnées **après** les BIG4_BASELINE (22-28) et DISTINCTIVE (29-33) — créant une discontinuité dans le bloc CORE visible dans la liste cockpit `/cockpit/brand/proposition` et dans le rendu `/shared/strategy/[token]`.
+
+**Fix** : `src/server/services/strategy-presentation/types.ts` — `SECTION_REGISTRY` réordonné en blocs contigus :
+- 01-21 CORE Phase 1-3 ADVERTIS + Mesure + Operationnel (inchangé)
+- **22-23 CORE Imhotep + Anubis** (déplacés de 34-35)
+- **24-30 BIG4_BASELINE** (renumérotés depuis 22-28)
+- **31-35 DISTINCTIVE** (renumérotés depuis 29-33)
+
+### Bug #2 — Imhotep + Anubis exclus du loader BrandAsset (sections rendues vides)
+`assemblePresentation` (et `checkCompleteness`) filtrait `phase13Sections = SECTION_REGISTRY.filter(s => s.tier && s.tier !== "CORE")` pour charger les BrandAssets côté lecture. Or **Imhotep et Anubis sont CORE** (Phase 14/15 actifs ADR-0019/0020) **mais leur data est BrandAsset-driven** (sequenceKey `IMHOTEP-CREW` / `ANUBIS-COMMS`, brandAssetKind=GENERIC, metadata.sectionId discriminant) — exactement comme BIG4/DISTINCTIVE. Conséquence : sections 22-23 rendaient vides côté Oracle même avec BrandAsset DRAFT présent en BDD.
+
+**Fix** : `src/server/services/strategy-presentation/index.ts` — filtre étendu dans `assemblePresentation` ET `checkCompleteness` :
+```ts
+const NETERU_GROUND_CORE_IDS = new Set(["imhotep-crew-program", "anubis-plan-comms"]);
+const phase13Sections = SECTION_REGISTRY.filter(
+  (s) => (s.tier && s.tier !== "CORE") || NETERU_GROUND_CORE_IDS.has(s.id),
+);
+```
+
+Validé live sur Bliss : `completeness` passe de `total=33+queued` à `total=35` avec Imhotep+Anubis détectées `partial` (DRAFT trouvé).
+
+### Bug #3 — Bouton Export PDF imprimait la mauvaise page
+Le bouton « Export PDF » dans `/cockpit/brand/proposition` appelait `window.print()` sur la page proposition (checklist + boutons) — pas sur l'Oracle. Le founder téléchargeait le mauvais document.
+
+**Fix** :
+- Nouvelle route HTTP `src/app/api/export/oracle/[strategyId]/pdf/route.ts` (GET, auth-required) qui délègue à `exportOracleAsPdf` (jspdf walk over les 35 sections via `assemblePresentation`) et stream le PDF avec `Content-Disposition: attachment; filename="oracle-<slug>-<date>.pdf"`.
+- Bouton refondé dans `src/app/(cockpit)/cockpit/brand/proposition/page.tsx` : `fetch('/api/export/oracle/${strategyId}/pdf')` → blob → `URL.createObjectURL` + `<a download>` programmatique → `URL.revokeObjectURL`.
+
+Validé live : route retourne 200 + `application/pdf` + signature `%PDF-1.3` + 376KB pour Bliss.
+
+### Vérification end-to-end (live navigateur, NEFER protocole 8 phases)
+- Oracle Bliss `/shared/strategy/[token]` : 35 sections rendent dans l'ordre canonique (01-23 CORE / 24-30 BIG4 / 31-35 DISTINCTIVE)
+- Sections 22 (Imhotep) + 23 (Anubis) ont leur content BrandAsset rendu (450px / 456px de hauteur, plus du placeholder vide)
+- Export PDF download fonctionne (376KB binaire valide)
+- **564/564 tests gouvernance passent** (incluant `oracle-registry-completeness` qui contrôle cardinalité 23+7+5 + numéros 01..35 strictement séquentiels + tier/brandAssetKind par section)
+- CODE-MAP.md régénéré (1390 lignes)
+
+**Cap APOGEE 7/7 préservé**. Pas de nouveau Neter, pas de bypass governance, pas de drift narratif. Les `id` de section restent stables (`imhotep-crew-program`, `mckinsey-7s`, etc.) — seuls les `number` d'affichage changent. Pas de migration Prisma nécessaire (BrandAsset.metadata.sectionId préservé).
+
 ## v6.19.19 — Modal portal (z-index escape) + CTA "Plateforme de marque" (2026-05-07)
 
 **Bug critique signalé au navigateur sur v6.19.18 : les tuiles de section Oracle (16-35) et autres éléments de la page brand passent AU-DESSUS du brand picker modal, malgré `z-[200]`. Cause racine identifiée : la sidebar cockpit est `sticky top-[var(--topbar-height)]` ET l'inner header a `relative z-[60]`, ce qui crée un stacking context borné. Le `z-[200]` du modal ne dépasse pas ce contexte parent — il est local au sidebar. Solution : portal vers `document.body`.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lafusee",
-  "version": "6.19.19",
+  "version": "6.19.20",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/(cockpit)/cockpit/brand/proposition/page.tsx
+++ b/src/app/(cockpit)/cockpit/brand/proposition/page.tsx
@@ -469,7 +469,32 @@ export default function PropositionPage() {
         )}
 
         <button
-          onClick={() => window.print()}
+          onClick={async () => {
+            // Streams the Oracle as PDF from /api/export/oracle/[strategyId]/pdf
+            // (server-side jspdf walk over the 35-section SECTION_REGISTRY).
+            // Replaces the legacy `window.print()` which printed the proposition
+            // index (checklist) instead of the Oracle itself.
+            if (!strategyId) return;
+            try {
+              const res = await fetch(`/api/export/oracle/${strategyId}/pdf`);
+              if (!res.ok) {
+                const err = await res.json().catch(() => ({ error: res.statusText }));
+                throw new Error(err.error ?? "Export failed");
+              }
+              const blob = await res.blob();
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download = res.headers.get("content-disposition")?.match(/filename="([^"]+)"/)?.[1] ?? "oracle.pdf";
+              document.body.appendChild(a);
+              a.click();
+              a.remove();
+              setTimeout(() => URL.revokeObjectURL(url), 2000);
+            } catch (e) {
+              console.error("[export-pdf] failed:", e);
+              alert("Export PDF a échoué. Voir la console.");
+            }
+          }}
           className="flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm text-foreground-secondary hover:bg-background"
         >
           Export PDF

--- a/src/app/api/export/oracle/[strategyId]/pdf/route.ts
+++ b/src/app/api/export/oracle/[strategyId]/pdf/route.ts
@@ -1,0 +1,70 @@
+/**
+ * /api/export/oracle/[strategyId]/pdf — Oracle PDF download (Phase 13 ADR-0014).
+ *
+ * Auth-required HTTP endpoint that streams the Oracle as PDF for download.
+ * Called from the cockpit `Export PDF` button (cf. cockpit/brand/proposition).
+ *
+ * Why this exists : the legacy `Export PDF` button called `window.print()` on
+ * the *proposition* index page (checklist + buttons), not on the Oracle render
+ * itself. That printed the wrong document. This route delegates to
+ * `exportOracleAsPdf` (server-side jspdf walk over the 35-section
+ * SECTION_REGISTRY via assemblePresentation), so the founder always gets the
+ * actual Oracle as a downloadable artifact regardless of which page they
+ * triggered the export from.
+ *
+ * Mission contribution : CHAIN_VIA:strategy-presentation (sustainment of the
+ * Oracle livrable across export channels).
+ */
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth/config";
+import { exportOracleAsPdf } from "@/server/services/strategy-presentation/export-oracle";
+import { db } from "@/lib/db";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ strategyId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { strategyId } = await params;
+
+  const strategy = await db.strategy.findUnique({
+    where: { id: strategyId },
+    select: { id: true, name: true },
+  });
+  if (!strategy) {
+    return NextResponse.json({ error: "Strategy not found" }, { status: 404 });
+  }
+
+  try {
+    const buffer = await exportOracleAsPdf(strategyId);
+    const filename = `oracle-${slugify(strategy.name)}-${new Date()
+      .toISOString()
+      .slice(0, 10)}.pdf`;
+    const body = new Uint8Array(buffer);
+    return new Response(body, {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Content-Length": String(body.byteLength),
+      },
+    });
+  } catch (error) {
+    console.error("[export/oracle/pdf] Failed:", error);
+    const message = error instanceof Error ? error.message : "Export failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80) || "strategy";
+}

--- a/src/server/services/strategy-presentation/index.ts
+++ b/src/server/services/strategy-presentation/index.ts
@@ -173,11 +173,11 @@ export async function assemblePresentation(strategyId: string): Promise<Strategy
   };
   const classification = classifyBrand(vector.composite);
 
-  // Phase 13 (B5/B6) — charger les BrandAssets des 14 sections étendues
-  // (BIG4 + DISTINCTIFS + DORMANTS) pour exposer leur content dans
-  // `doc.sections[sectionId]`. Sans ce merge, presentation-layout reçoit
-  // `sectionData = undefined` et le composant Phase 13 crash sur
-  // `data.<field>`. Cf. SECTION_DATA_MAP qui mappe sectionId → identité.
+  // Phase 13 (B5/B6) — charger les BrandAssets des sections BrandAsset-driven
+  // (BIG4 + DISTINCTIFS + Neteru Ground actifs Imhotep/Anubis) pour exposer
+  // leur content dans `doc.sections[sectionId]`. Sans ce merge, presentation-
+  // layout reçoit `sectionData = undefined` et le composant Phase 13 crash
+  // sur `data.<field>`. Cf. SECTION_DATA_MAP qui mappe sectionId → identité.
   //
   // ACTIVE preferred, DRAFT as fallback. The Glory sequences write back
   // BrandAsset.state="DRAFT" (cf. promoteSectionToBrandAsset). Promotion
@@ -187,7 +187,17 @@ export async function assemblePresentation(strategyId: string): Promise<Strategy
   // BCG_PORTFOLIO content present in DRAFT — bcgPortfolio.stars,
   // cash_cows, question_marks fully populated — but Oracle rendered
   // "Portfolio non encore tracé"). Falling back to DRAFT closes that gap.
-  const phase13Sections = SECTION_REGISTRY.filter((s) => s.tier && s.tier !== "CORE");
+  //
+  // Imhotep + Anubis : tier CORE post-Phase 17 ADR-0045 (Phase 14/15 actifs)
+  // mais leur data est BrandAsset-driven exactement comme BIG4/DISTINCTIVE
+  // (sequenceKey IMHOTEP-CREW / ANUBIS-COMMS, brandAssetKind=GENERIC,
+  // metadata.sectionId discriminant). Sans inclusion explicite ici, leurs
+  // sections rendent vides côté UI (BLISS 2026-05-07 : sections 22-23 "queued"
+  // alors que BrandAsset DRAFT existait — observé en live navigateur).
+  const NETERU_GROUND_CORE_IDS = new Set(["imhotep-crew-program", "anubis-plan-comms"]);
+  const phase13Sections = SECTION_REGISTRY.filter(
+    (s) => (s.tier && s.tier !== "CORE") || NETERU_GROUND_CORE_IDS.has(s.id),
+  );
   const phase13Kinds = [
     ...new Set(
       phase13Sections.map((s) => s.brandAssetKind).filter(Boolean) as string[],
@@ -367,7 +377,14 @@ export async function checkCompleteness(strategyId: string): Promise<Completenes
   const doc = await assemblePresentation(strategyId);
   const baseReport = checkSectionCompleteness(doc);
 
-  const phase13Sections = SECTION_REGISTRY.filter((s) => s.tier && s.tier !== "CORE");
+  // Cf. assemblePresentation : Imhotep + Anubis sont CORE mais BrandAsset-driven.
+  const NETERU_GROUND_CORE_IDS_COMPLETENESS = new Set([
+    "imhotep-crew-program",
+    "anubis-plan-comms",
+  ]);
+  const phase13Sections = SECTION_REGISTRY.filter(
+    (s) => (s.tier && s.tier !== "CORE") || NETERU_GROUND_CORE_IDS_COMPLETENESS.has(s.id),
+  );
   if (phase13Sections.length === 0) return baseReport;
 
   const { db } = await import("@/lib/db");

--- a/src/server/services/strategy-presentation/types.ts
+++ b/src/server/services/strategy-presentation/types.ts
@@ -78,7 +78,8 @@ export interface SectionMeta {
 }
 
 export const SECTION_REGISTRY: SectionMeta[] = [
-  // ─── CORE (21 sections actives — Phase 1-3 ADVERTIS + Mesure + Operationnel) ──
+  // ─── CORE (23 sections actives — Phase 1-3 ADVERTIS + Mesure + Operationnel
+  //          + Imhotep Crew Program + Anubis Plan Comms) ─────────────────────
   // ── Phase 1: ADVE — Identite ──────────────────────────────────────────────
   { id: "executive-summary", number: "01", title: "Executive Summary", personas: ["consultant", "client", "creative"], tier: "CORE", brandAssetKind: "GENERIC" },
   { id: "contexte-defi", number: "02", title: "Contexte & Defi", personas: ["consultant", "client"], tier: "CORE", brandAssetKind: "MANIFESTO" },
@@ -105,26 +106,29 @@ export const SECTION_REGISTRY: SectionMeta[] = [
   { id: "timeline-gouvernance", number: "19", title: "Timeline & Gouvernance", personas: ["consultant", "client"], tier: "CORE", brandAssetKind: "GENERIC" },
   { id: "equipe", number: "20", title: "Equipe", personas: ["consultant"], tier: "CORE", brandAssetKind: "GENERIC" },
   { id: "conditions-etapes", number: "21", title: "Conditions & Prochaines Etapes", personas: ["consultant", "client"], tier: "CORE", brandAssetKind: "GENERIC" },
+  // ── Neteru Ground actifs (Phase 14/15 — ADR-0019 + ADR-0020) ──────────────
+  // Imhotep + Anubis sont CORE post Phase 17 ADR-0045. Leur data est BrandAsset-
+  // driven (sequenceKey + brandAssetKind=GENERIC + metadata.sectionId), comme
+  // les BIG4/DISTINCTIVE — donc le loader phase13Sections dans index.ts inclut
+  // ces deux ids même si leur tier reste CORE.
+  { id: "imhotep-crew-program", number: "22", title: "Crew Program (Imhotep)", personas: ["consultant"], tier: "CORE", brandAssetKind: "GENERIC", sequenceKey: "IMHOTEP-CREW" },
+  { id: "anubis-plan-comms", number: "23", title: "Plan Comms (Anubis)", personas: ["consultant"], tier: "CORE", brandAssetKind: "GENERIC", sequenceKey: "ANUBIS-COMMS" },
 
   // ─── BIG4_BASELINE (7 sections — frameworks consulting one-shot) ──────────
-  { id: "mckinsey-7s", number: "22", title: "McKinsey 7S Framework", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "MCK_7S", sequenceKey: "MCK-7S" },
-  { id: "bcg-portfolio", number: "23", title: "BCG Growth-Share Matrix", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "BCG_PORTFOLIO", sequenceKey: "BCG-PORTFOLIO" },
-  { id: "bain-nps", number: "24", title: "Bain Net Promoter System", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "BAIN_NPS", sequenceKey: "BAIN-NPS" },
-  { id: "deloitte-greenhouse", number: "25", title: "Deloitte Greenhouse (Talent Program)", personas: ["consultant"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "DELOITTE_GREENHOUSE", sequenceKey: "DELOITTE-GREENHOUSE" },
-  { id: "mckinsey-3-horizons", number: "26", title: "McKinsey Three Horizons of Growth", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "MCK_3H", sequenceKey: "MCK-3H" },
-  { id: "bcg-strategy-palette", number: "27", title: "BCG Strategy Palette", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "BCG_STRATEGY_PALETTE", sequenceKey: "BCG-PALETTE" },
-  { id: "deloitte-budget", number: "28", title: "Deloitte Budget Framework", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "DELOITTE_BUDGET", sequenceKey: "DELOITTE-BUDGET" },
+  { id: "mckinsey-7s", number: "24", title: "McKinsey 7S Framework", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "MCK_7S", sequenceKey: "MCK-7S" },
+  { id: "bcg-portfolio", number: "25", title: "BCG Growth-Share Matrix", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "BCG_PORTFOLIO", sequenceKey: "BCG-PORTFOLIO" },
+  { id: "bain-nps", number: "26", title: "Bain Net Promoter System", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "BAIN_NPS", sequenceKey: "BAIN-NPS" },
+  { id: "deloitte-greenhouse", number: "27", title: "Deloitte Greenhouse (Talent Program)", personas: ["consultant"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "DELOITTE_GREENHOUSE", sequenceKey: "DELOITTE-GREENHOUSE" },
+  { id: "mckinsey-3-horizons", number: "28", title: "McKinsey Three Horizons of Growth", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "MCK_3H", sequenceKey: "MCK-3H" },
+  { id: "bcg-strategy-palette", number: "29", title: "BCG Strategy Palette", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "BCG_STRATEGY_PALETTE", sequenceKey: "BCG-PALETTE" },
+  { id: "deloitte-budget", number: "30", title: "Deloitte Budget Framework", personas: ["consultant", "client"], tier: "BIG4_BASELINE", isBaseline: true, brandAssetKind: "DELOITTE_BUDGET", sequenceKey: "DELOITTE-BUDGET" },
 
   // ─── DISTINCTIVE (5 sections — valeur ajoutée La Fusée vs Big4) ───────────
-  { id: "cult-index", number: "29", title: "Cult Index — Score de masse culturelle", personas: ["consultant", "client"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "CULT_INDEX", sequenceKey: "CULT-INDEX" },
-  { id: "manipulation-matrix", number: "30", title: "Manipulation Matrix — 4 modes d'engagement", personas: ["consultant", "client", "creative"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "MANIPULATION_MATRIX", sequenceKey: "MANIP-MATRIX" },
-  { id: "devotion-ladder", number: "31", title: "Devotion Ladder — Hiérarchie superfans", personas: ["consultant", "client"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "SUPERFAN_JOURNEY", sequenceKey: "DEVOTION-LADDER" },
-  { id: "overton-distinctive", number: "32", title: "Overton Distinctive — Position fenêtre culturelle", personas: ["consultant", "client"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "OVERTON_WINDOW", sequenceKey: "OVERTON-DISTINCTIVE" },
-  { id: "tarsis-weak-signals", number: "33", title: "Tarsis — Signaux faibles sectoriels", personas: ["consultant"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "TREND_RADAR", sequenceKey: "TARSIS-WEAK" },
-
-  // ─── CORE — Imhotep Crew Program + Anubis Plan Comms (Phase 14/15 actifs, ADR-0019 + ADR-0020) ──
-  { id: "imhotep-crew-program", number: "34", title: "Crew Program (Imhotep)", personas: ["consultant"], tier: "CORE", brandAssetKind: "GENERIC", sequenceKey: "IMHOTEP-CREW" },
-  { id: "anubis-plan-comms", number: "35", title: "Plan Comms (Anubis)", personas: ["consultant"], tier: "CORE", brandAssetKind: "GENERIC", sequenceKey: "ANUBIS-COMMS" },
+  { id: "cult-index", number: "31", title: "Cult Index — Score de masse culturelle", personas: ["consultant", "client"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "CULT_INDEX", sequenceKey: "CULT-INDEX" },
+  { id: "manipulation-matrix", number: "32", title: "Manipulation Matrix — 4 modes d'engagement", personas: ["consultant", "client", "creative"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "MANIPULATION_MATRIX", sequenceKey: "MANIP-MATRIX" },
+  { id: "devotion-ladder", number: "33", title: "Devotion Ladder — Hiérarchie superfans", personas: ["consultant", "client"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "SUPERFAN_JOURNEY", sequenceKey: "DEVOTION-LADDER" },
+  { id: "overton-distinctive", number: "34", title: "Overton Distinctive — Position fenêtre culturelle", personas: ["consultant", "client"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "OVERTON_WINDOW", sequenceKey: "OVERTON-DISTINCTIVE" },
+  { id: "tarsis-weak-signals", number: "35", title: "Tarsis — Signaux faibles sectoriels", personas: ["consultant"], tier: "DISTINCTIVE", isDistinctive: true, brandAssetKind: "TREND_RADAR", sequenceKey: "TARSIS-WEAK" },
 ];
 
 /**


### PR DESCRIPTION
## Pourquoi le travail apparaissait incomplet

Sur le screenshot du cockpit (avant ce PR) :
- **Imhotep #34 + Anubis #35** placés en queue du bloc CORE après BIG4 et DISTINCTIVE → discontinuité visuelle
- Sections 34-35 marquées **« Vide »** dans la liste, alors que leur BrandAsset DRAFT existe en BDD
- Compteur incohérent : `20 complets + 13 partiels + 0 vides = 33` ≠ `20/35` (2 sections invisibles au compte)
- Bouton **« Export PDF »** imprimait la page proposition (checklist), pas l'Oracle

3 bugs profonds débuggés en live navigateur sur Bliss (`wk-strategy-bliss`), root cause par couche, fix-tested-committed sans skip de phase NEFER.

## Bug #1 — Ordre incohérent SECTION_REGISTRY
Sections #34/#35 (CORE) placées après BIG4 (22-28) et DISTINCTIVE (29-33).

**Fix** : `src/server/services/strategy-presentation/types.ts` réordonné :
- 01-21 CORE ADVERTIS + Mesure + Operationnel
- **22-23 CORE Imhotep + Anubis** (déplacés depuis 34-35)
- 24-30 BIG4_BASELINE
- 31-35 DISTINCTIVE

## Bug #2 — Imhotep/Anubis exclus du loader BrandAsset
`assemblePresentation` filtrait `phase13Sections = filter(s => s.tier !== "CORE")` pour charger les BrandAssets côté lecture. Imhotep+Anubis sont **CORE** mais leur data est **BrandAsset-driven** (sequenceKey + brandAssetKind GENERIC + metadata.sectionId) comme BIG4/DISTINCTIVE → sections rendues vides en prod malgré DRAFT en BDD.

**Fix** : `src/server/services/strategy-presentation/index.ts` (assemblePresentation + checkCompleteness) avec `NETERU_GROUND_CORE_IDS = Set("imhotep-crew-program", "anubis-plan-comms")`.

## Bug #3 — Bouton Export PDF cassé
`window.print()` imprimait la page proposition au lieu de l'Oracle.

**Fix** :
- Nouvelle route HTTP `/api/export/oracle/[strategyId]/pdf` (auth-required, jspdf via assemblePresentation)
- Bouton refondé : `fetch` + blob + `<a download>` programmatique

## Test plan
- [x] Validé live navigateur Bliss : 35 sections rendent dans l'ordre canonique (01-23 / 24-30 / 31-35)
- [x] Sections 22 (Imhotep) + 23 (Anubis) ont leur content BrandAsset rendu (450/456px de hauteur)
- [x] Export PDF retourne 200 + application/pdf + signature %PDF-1.3 + 376KB pour Bliss
- [x] 564/564 tests gouvernance passent
- [x] CODE-MAP.md régénéré (1390 lignes)
- [x] Cap APOGEE 7/7 préservé, ids stables, pas de migration Prisma

🤖 Generated with [Claude Code](https://claude.com/claude-code)