### PR TITLE
feat(cockpit+glory): livrables launch/social opérationnels + pipeline canonique déterministe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 
 ---
 
+## v6.26.1 — feat(cockpit) : hub Livrables opérationnel — plan de lancement, calendrier & kit social surfacés (2026-06-15)
+
+**Les livrables opérationnels existent enfin dans la section dédiée.** Audit SPAWT (`spawt-strategy-001`) : les 4 GloryOutput de prélancement (`launch-timeline-planner` GTM, `content-calendar-strategist` cadence + hashtags, `naming-generator` comptes, `social-copy-engine` bios) étaient **générés et en base** depuis le 2026-06-13, mais le calendrier de prélancement n'exposait que timeline/cadence/hashtags, et les **comptes + bios social n'étaient surfacés nulle part** — absents aussi de `/cockpit/brand/deliverables` (section séquence-centrée). Ce ne sont **pas** des données Oracle : ce sont des livrables opérationnels, qui doivent vivre dans la section Livrables.
+
+- `feat(types)` `parseSocialNaming` + `parseSocialCopy` (purs, défensifs — `null` si shape absente, jamais de throw) dans `launch-calendar.ts` : handles/replis/stratégie de nommage + bios/voix/highlights/mots-clés/link-in-bio par plateforme.
+- `feat(trpc)` `glory.launchCalendar` étendu : lit désormais les **4** slugs launch/social et renvoie `{ timeline, calendar, naming, social, generatedAt }` (rétro-compat, lecture pure tenant-scopée).
+- `feat(cockpit)` `/cockpit/operate/calendar` complété : section **Présence social** (comptes recommandés + replis, bios/copy par plateforme avec bouton copier, link-in-bio). Titre → « plan de prélancement digital & social ».
+- `feat(cockpit)` **réorganisation `/cockpit/brand/deliverables` en hub opérationnel** : catégorie *Opérationnel — lancement, contenu & social* (cartes Plan de lancement GTM · Calendrier éditorial + copie hashtags · Kit social + copie comptes, liens vers le plan complet) ; catégorie *Documents compilables* (existant) ; *Raccourcis*. Stats enrichies (kits opérationnels).
+- `feat(shared)` `CopyButton` partagé DS-compliant — micro-actions opérationnelles (copier hashtags / comptes), dégradation silencieuse hors contexte sécurisé.
+- Aucune donnée Oracle touchée. Cap APOGEE 7/7 préservé. `tsc --noEmit` 0 · eslint 0 · governance DS (cascade/canonical/CVA) + oracle-section-coherence verts · parsers vérifiés sur les shapes réelles SPAWT (7 handles, 6 profils).
+
+---
+
 ## v6.26.0 — feat(ds) : UPgraders Design System = source de vérité unique (ADR-0097, supersedes 0013) (2026-06-14)
 
 **Canon refresh DS complet.** Adoption du handoff **UPgraders Design System** (*« La Passion pour Propulseur »*, claude.ai/design) comme source de vérité unique du design, sur décision opérateur. Architecture ADR-0013 conservée (cascade 4 tiers, 3 interdits, gouvernance CI), valeurs remplacées.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Systeme de versionnage : **`MAJEURE.PHASE.ITERATION`**
 
 ---
 
+## v6.26.2 — feat(glory) : pipeline canonique déterministe launch/social (ADVERTIS → Glory, 0 LLM) + posts datés (2026-06-15)
+
+**Cause racine corrigée.** Les 4 outils de prélancement (`naming-generator`, `social-copy-engine`, `content-calendar-strategist`, `launch-timeline-planner`) n'avaient **aucun `outputSchema`** → le chemin canonique `executeTool` (ADVERTIS → Glory) ne garantissait pas la shape, d'où des outputs écrits à la main hors process (`generatedBy: NEFER déterministe`). Désormais produits déterministement depuis les piliers, par le pipeline canonique.
+
+- `feat(glory)` **composers déterministes** [`glory-composers.ts`](src/server/services/artemis/tools/glory-composers.ts) : 4 composers (0 LLM) qui assemblent handles / bios / cadence / timeline depuis A/D/V/E/I/S. Branchés dans `executeTool` **avant** le chemin LLM (provenance `DETERMINISTIC_COMPOSE`). Reproductible pour toute marque, sans clé LLM.
+- `feat(glory)` **`outputSchema` (Zod)** sur les 4 tools ([`launch-social-schemas.ts`](src/server/services/artemis/tools/launch-social-schemas.ts)) — contrat verrouillé, source unique partagée registry + composers + validation.
+- `feat(types)` **posts datés un-par-un** : `ContentPost` + `deriveDatedPosts` (pur, déterministe) — calendrier de publication daté (date / jour / plateforme / thème / angle / hashtags / statut), produit par le composer **ou** dérivé read-time depuis la cadence (les outputs antérieurs, sans re-run, en bénéficient).
+- `feat(cockpit)` `/cockpit/operate/calendar` : section **Calendrier de publication** (posts groupés par semaine). Hub Livrables : compteur de posts datés sur la carte Calendrier éditorial.
+- `feat(trpc)` `glory.launchCalendar` : dérive les posts au read-time (ancrés sur la timeline J1) quand l'output stocké n'en porte pas.
+- `test` [`glory-composers.test.ts`](tests/unit/services/glory-composers.test.ts) (12) : couverture 4/4, validation schémas, handles cross-plateforme `@marque.marché`, hashtags depuis le slogan, posts datés, déterminisme variance 0, honnêteté sur pilier vide.
+- `tsc --noEmit` 0 · eslint 0 · **817 tests gouvernance + 12 composers verts**. Cap APOGEE 7/7 préservé (aucun nouveau Neter — sous-domaine Artemis).
+
+---
+
 ## v6.26.1 — feat(cockpit) : hub Livrables opérationnel — plan de lancement, calendrier & kit social surfacés (2026-06-15)
 
 **Les livrables opérationnels existent enfin dans la section dédiée.** Audit SPAWT (`spawt-strategy-001`) : les 4 GloryOutput de prélancement (`launch-timeline-planner` GTM, `content-calendar-strategist` cadence + hashtags, `naming-generator` comptes, `social-copy-engine` bios) étaient **générés et en base** depuis le 2026-06-13, mais le calendrier de prélancement n'exposait que timeline/cadence/hashtags, et les **comptes + bios social n'étaient surfacés nulle part** — absents aussi de `/cockpit/brand/deliverables` (section séquence-centrée). Ce ne sont **pas** des données Oracle : ce sont des livrables opérationnels, qui doivent vivre dans la section Livrables.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lafusee",
-  "version": "6.26.1",
+  "version": "6.26.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lafusee",
-  "version": "6.26.0",
+  "version": "6.26.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/(cockpit)/cockpit/brand/deliverables/page.tsx
+++ b/src/app/(cockpit)/cockpit/brand/deliverables/page.tsx
@@ -478,7 +478,10 @@ function OperationalDeliverables({ kit, isLoading }: { kit: LaunchKit; isLoading
             copyValue={allHashtags.length ? allHashtags.join(" ") : undefined}
             copyLabel="Copier les hashtags"
           >
-            <p className="text-xs text-foreground-muted">{Object.keys(calendar.cadenceParCanal).length} canaux · cadence définie</p>
+            <p className="text-xs text-foreground-muted">
+              {Object.keys(calendar.cadenceParCanal).length} canaux
+              {calendar.posts.length > 0 ? ` · ${calendar.posts.length} posts datés` : " · cadence définie"}
+            </p>
             {allHashtags.length ? (
               <div className="flex flex-wrap gap-1">
                 {allHashtags.slice(0, 6).map((h) => (

--- a/src/app/(cockpit)/cockpit/brand/deliverables/page.tsx
+++ b/src/app/(cockpit)/cockpit/brand/deliverables/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { trpc } from "@/lib/trpc/client";
 import { PageHeader } from "@/components/shared/page-header";
 import { StatCard } from "@/components/shared/stat-card";
 import { EmptyState } from "@/components/shared/empty-state";
-import { StatusBadge } from "@/components/shared/status-badge";
 import { Modal } from "@/components/shared/modal";
 import { SkeletonPage } from "@/components/shared/loading-skeleton";
+import { CopyButton } from "@/components/shared/copy-button";
 import { useCurrentStrategyId } from "@/components/cockpit/strategy-context";
 import { getFieldLabel } from "@/components/cockpit/field-renderers";
+import type { LaunchTimeline, ContentCalendar, SocialNaming, SocialCopy } from "@/lib/types/launch-calendar";
 import {
   FileText,
   Download,
@@ -20,8 +21,14 @@ import {
   Globe,
   BookOpen,
   Image,
-  Palette,
-  Shield,
+  CalendarDays,
+  Hash,
+  AtSign,
+  Rocket,
+  Radio,
+  ArrowRight,
+  Layers,
+  type LucideIcon,
 } from "lucide-react";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -40,6 +47,13 @@ export default function BrandDeliverablesPage() {
   const [expandedSection, setExpandedSection] = useState<number | null>(null);
 
   const deliverablesQuery = trpc.glory.compilableDeliverables.useQuery(
+    { strategyId: strategyId ?? "" },
+    { enabled: !!strategyId },
+  );
+
+  // Operational launch/social kit (GTM timeline, editorial calendar, handles,
+  // bios) — standalone GloryOutputs surfaced as first-class deliverables.
+  const launchKitQuery = trpc.glory.launchCalendar.useQuery(
     { strategyId: strategyId ?? "" },
     { enabled: !!strategyId },
   );
@@ -71,6 +85,10 @@ export default function BrandDeliverablesPage() {
   const complete = deliverables.filter((d) => d.isComplete);
   const partial = deliverables.filter((d) => !d.isComplete);
 
+  const kit = launchKitQuery.data ?? null;
+  const hasSocialKit = Boolean(kit?.naming || kit?.social);
+  const opCount = [Boolean(kit?.timeline), Boolean(kit?.calendar), hasSocialKit].filter(Boolean).length;
+
   if (!strategyId) {
     return (
       <div className="space-y-6">
@@ -90,41 +108,29 @@ export default function BrandDeliverablesPage() {
     <div className="space-y-6">
       <PageHeader
         title="Livrables"
-        description={`${complete.length} prets a exporter, ${partial.length} en cours de completion`}
+        description={`${opCount} kit${opCount > 1 ? "s" : ""} operationnel${opCount > 1 ? "s" : ""} · ${complete.length} document${complete.length > 1 ? "s" : ""} pret${complete.length > 1 ? "s" : ""} a exporter`}
         breadcrumbs={[{ label: "Cockpit", href: "/cockpit" }, { label: "Brand" }, { label: "Livrables" }]}
       />
 
       {/* Stats */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard title="Kits operationnels" value={opCount} icon={Rocket} />
         <StatCard title="Prets a exporter" value={complete.length} icon={CheckCircle} />
         <StatCard title="En cours" value={partial.length} icon={RefreshCw} />
-        <StatCard title="Total" value={deliverables.length} icon={FileText} />
+        <StatCard title="Total documents" value={deliverables.length} icon={FileText} />
       </div>
 
-      {/* Quick links to existing brand pages */}
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <a href="/cockpit/brand/guidelines" className="flex items-center gap-3 rounded-xl border border-border bg-background/80 p-4 hover:border-border transition-colors">
-          <BookOpen className="h-5 w-5 text-amber-400" />
-          <div>
-            <p className="text-sm font-medium text-white">Brand Guidelines</p>
-            <p className="text-[10px] text-foreground-muted">Issu de la sequence BRANDBOOK-D</p>
-          </div>
-        </a>
-        <a href="/cockpit/brand/assets" className="flex items-center gap-3 rounded-xl border border-border bg-background/80 p-4 hover:border-border transition-colors">
-          <Image className="h-5 w-5 text-blue-400" />
-          <div>
-            <p className="text-sm font-medium text-white">Assets Visuels</p>
-            <p className="text-[10px] text-foreground-muted">KV, logos, chromatic, typo</p>
-          </div>
-        </a>
-        <a href="/cockpit/brand/identity" className="flex items-center gap-3 rounded-xl border border-border bg-background/80 p-4 hover:border-border transition-colors">
-          <Palette className="h-5 w-5 text-emerald-400" />
-          <div>
-            <p className="text-sm font-medium text-white">Identite</p>
-            <p className="text-[10px] text-foreground-muted">Pilier A — manifeste, archetype, voix</p>
-          </div>
-        </a>
-      </div>
+      {/* ── Operationnel — Lancement, contenu & social ─────────────── */}
+      <OperationalDeliverables kit={kit} isLoading={launchKitQuery.isLoading} />
+
+      {/* ── Documents compilables ──────────────────────────────────── */}
+      {deliverables.length > 0 ? (
+        <div className="flex items-center gap-3 pt-2">
+          <Layers className="h-4 w-4 text-foreground-muted" />
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-foreground-secondary">Documents compilables</h2>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+      ) : null}
 
       {/* Complete deliverables — ready to export */}
       {complete.length > 0 && (
@@ -215,13 +221,43 @@ export default function BrandDeliverablesPage() {
         </div>
       )}
 
-      {deliverables.length === 0 && (
+      {deliverables.length === 0 && opCount === 0 && !launchKitQuery.isLoading && (
         <EmptyState
           icon={FileText}
           title="Aucun livrable"
-          description="Lancez des sequences GLORY pour generer des livrables compilables."
+          description="Lancez des sequences GLORY ou le plan de lancement pour generer des livrables."
         />
       )}
+
+      {/* ── Raccourcis — surfaces marque connexes ──────────────────── */}
+      <div className="flex items-center gap-3 pt-2">
+        <ArrowRight className="h-4 w-4 text-foreground-muted" />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-foreground-secondary">Raccourcis</h2>
+        <div className="h-px flex-1 bg-border" />
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <a href="/cockpit/operate/calendar" className="flex items-center gap-3 rounded-xl border border-border bg-surface-raised p-4 hover:border-accent/40 transition-colors">
+          <CalendarDays className="h-5 w-5 text-accent" />
+          <div>
+            <p className="text-sm font-medium text-foreground">Plan de lancement</p>
+            <p className="text-[10px] text-foreground-muted">GTM, cadence, hashtags & social</p>
+          </div>
+        </a>
+        <a href="/cockpit/brand/guidelines" className="flex items-center gap-3 rounded-xl border border-border bg-surface-raised p-4 hover:border-accent/40 transition-colors">
+          <BookOpen className="h-5 w-5 text-foreground-secondary" />
+          <div>
+            <p className="text-sm font-medium text-foreground">Brand Guidelines</p>
+            <p className="text-[10px] text-foreground-muted">Issu de la sequence BRANDBOOK-D</p>
+          </div>
+        </a>
+        <a href="/cockpit/brand/assets" className="flex items-center gap-3 rounded-xl border border-border bg-surface-raised p-4 hover:border-accent/40 transition-colors">
+          <Image className="h-5 w-5 text-foreground-secondary" />
+          <div>
+            <p className="text-sm font-medium text-foreground">Assets Visuels</p>
+            <p className="text-[10px] text-foreground-muted">KV, logos, chromatic, typo</p>
+          </div>
+        </a>
+      </div>
 
       {/* Deliverable Detail Modal */}
       <Modal
@@ -373,6 +409,148 @@ export default function BrandDeliverablesPage() {
           );
         })() : null}
       </Modal>
+    </div>
+  );
+}
+
+// ─── Operational deliverables (launch / content / social) ─────────────────────
+
+type LaunchKit = {
+  timeline: LaunchTimeline | null;
+  calendar: ContentCalendar | null;
+  naming: SocialNaming | null;
+  social: SocialCopy | null;
+  generatedAt: string | null;
+} | null;
+
+function OperationalDeliverables({ kit, isLoading }: { kit: LaunchKit; isLoading: boolean }) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="h-44 animate-pulse rounded-xl border border-border bg-surface-raised" />
+        ))}
+      </div>
+    );
+  }
+
+  const timeline = kit?.timeline ?? null;
+  const calendar = kit?.calendar ?? null;
+  const naming = kit?.naming ?? null;
+  const social = kit?.social ?? null;
+  if (!timeline && !calendar && !naming && !social) return null;
+
+  const allHashtags = calendar ? [...calendar.hashtags.signature, ...calendar.hashtags.local] : [];
+  const handleLines = naming ? naming.handles.map((h) => `${h.platform}: ${h.value}`).join("\n") : "";
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center gap-3">
+        <Rocket className="h-4 w-4 text-accent" />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-foreground-secondary">
+          Operationnel — lancement, contenu &amp; social
+        </h2>
+        <div className="h-px flex-1 bg-border" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {timeline ? (
+          <OpCard icon={CalendarDays} title="Plan de lancement (GTM)" badge="Go-to-market">
+            <p className="text-xs text-foreground-muted">{timeline.weeks.length} phases J-ancrées</p>
+            <div className="flex flex-wrap gap-1">
+              {timeline.weeks.slice(0, 4).map((w, i) => (
+                <span key={i} className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-foreground-secondary">
+                  {w.semaine} · {w.phase.split(" — ")[0] ?? w.phase}
+                </span>
+              ))}
+              {timeline.weeks.length > 4 ? (
+                <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-foreground-muted">+{timeline.weeks.length - 4}</span>
+              ) : null}
+            </div>
+          </OpCard>
+        ) : null}
+
+        {calendar ? (
+          <OpCard
+            icon={Radio}
+            title="Calendrier éditorial"
+            badge="Contenu"
+            copyValue={allHashtags.length ? allHashtags.join(" ") : undefined}
+            copyLabel="Copier les hashtags"
+          >
+            <p className="text-xs text-foreground-muted">{Object.keys(calendar.cadenceParCanal).length} canaux · cadence définie</p>
+            {allHashtags.length ? (
+              <div className="flex flex-wrap gap-1">
+                {allHashtags.slice(0, 6).map((h) => (
+                  <span key={h} className="inline-flex items-center gap-0.5 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] text-accent">
+                    <Hash className="h-2.5 w-2.5" />{h.replace(/^#/, "")}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </OpCard>
+        ) : null}
+
+        {naming || social ? (
+          <OpCard
+            icon={AtSign}
+            title="Kit social — comptes & bios"
+            badge="Social"
+            copyValue={handleLines || undefined}
+            copyLabel="Copier les comptes"
+          >
+            <p className="text-xs text-foreground-muted">
+              {naming ? `${naming.handles.length} comptes` : ""}
+              {naming && social ? " · " : ""}
+              {social ? `${social.profiles.length} bios` : ""}
+            </p>
+            {naming && naming.handles.length ? (
+              <div className="flex flex-wrap gap-1">
+                {naming.handles.slice(0, 5).map((h) => (
+                  <span key={h.key} className="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-foreground-secondary">{h.value}</span>
+                ))}
+              </div>
+            ) : null}
+          </OpCard>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function OpCard({
+  icon: Icon,
+  title,
+  badge,
+  children,
+  copyValue,
+  copyLabel,
+}: {
+  icon: LucideIcon;
+  title: string;
+  badge: string;
+  children: ReactNode;
+  copyValue?: string;
+  copyLabel?: string;
+}) {
+  return (
+    <div className="flex flex-col rounded-xl border border-border bg-surface-raised p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent/10">
+            <Icon className="h-4 w-4 text-accent" />
+          </div>
+          <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        </div>
+        <span className="rounded-full bg-white/5 px-2 py-0.5 text-[9px] uppercase tracking-widest text-foreground-muted">{badge}</span>
+      </div>
+      <div className="flex-1 space-y-2">{children}</div>
+      <div className="mt-4 flex items-center justify-between gap-2 border-t border-border-subtle pt-3">
+        <a href="/cockpit/operate/calendar" className="inline-flex items-center gap-1.5 text-xs font-semibold text-accent hover:underline">
+          Consulter <ArrowRight className="h-3.5 w-3.5" />
+        </a>
+        {copyValue ? <CopyButton value={copyValue} label={copyLabel ?? "Copier"} /> : null}
+      </div>
     </div>
   );
 }

--- a/src/components/cockpit/launch-calendar-panel.tsx
+++ b/src/components/cockpit/launch-calendar-panel.tsx
@@ -13,7 +13,7 @@ import { trpc } from "@/lib/trpc/client";
 import { useCurrentStrategyId } from "@/components/cockpit/strategy-context";
 import { SkeletonPage } from "@/components/shared/loading-skeleton";
 import { CopyButton } from "@/components/shared/copy-button";
-import type { LaunchTimelineWeek, SocialNaming, SocialCopy } from "@/lib/types/launch-calendar";
+import type { LaunchTimelineWeek, SocialNaming, SocialCopy, ContentPost } from "@/lib/types/launch-calendar";
 
 function isGate(kpi: string): boolean {
   return /gate|go\s*\/\s*no[- ]?go/i.test(kpi);
@@ -101,6 +101,29 @@ export function LaunchCalendarPanel() {
                         ))}
                       </ul>
                     ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {calendar.posts.length > 0 ? (
+            <div>
+              <SectionHeader icon={CalendarDays} label="Calendrier de publication" suffix={`${calendar.posts.length} posts`} />
+              <div className="space-y-6">
+                {groupPostsByWeek(calendar.posts).map(([week, posts]) => (
+                  <div key={week}>
+                    <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-accent">{week}</div>
+                    <ol className="space-y-1.5">
+                      {posts.map((p, i) => (
+                        <li key={i} className="flex items-center gap-3 rounded-lg border border-white/5 bg-surface-raised px-3 py-2">
+                          <span className="w-28 shrink-0 font-mono text-[10px] text-foreground-muted">{p.weekday} {formatPostDate(p.date)}</span>
+                          <span className="shrink-0 rounded bg-accent/15 px-1.5 py-0.5 text-[10px] text-accent">{p.platform}</span>
+                          <span className="min-w-0 flex-1 truncate text-xs text-foreground-secondary">{p.theme ?? p.angle ?? p.format ?? "Publication"}</span>
+                          {p.format ? <span className="hidden shrink-0 text-[10px] text-foreground-muted md:inline">{p.format}</span> : null}
+                        </li>
+                      ))}
+                    </ol>
                   </div>
                 ))}
               </div>
@@ -349,4 +372,21 @@ function WeekRow({ week, isLast }: { week: LaunchTimelineWeek; isLast: boolean }
       </div>
     </li>
   );
+}
+
+function formatPostDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("fr-FR", { day: "numeric", month: "short", timeZone: "UTC" });
+}
+
+function groupPostsByWeek(posts: ContentPost[]): Array<[string, ContentPost[]]> {
+  const groups = new Map<string, ContentPost[]>();
+  for (const p of posts) {
+    const key = p.week ?? "—";
+    const list = groups.get(key) ?? [];
+    list.push(p);
+    groups.set(key, list);
+  }
+  return Array.from(groups.entries());
 }

--- a/src/components/cockpit/launch-calendar-panel.tsx
+++ b/src/components/cockpit/launch-calendar-panel.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 /**
- * LaunchCalendarPanel — renders the launch calendar Glory deliverables
- * (`launch-timeline-planner` + `content-calendar-strategist` GloryOutputs) as a
- * consumable cockpit surface, instead of leaving them as dormant JSON in the
- * vault. Read-only projection via `trpc.glory.launchCalendar`. (Phase 24.)
+ * LaunchCalendarPanel — renders the launch/social Glory deliverables
+ * (`launch-timeline-planner` + `content-calendar-strategist` + `naming-generator`
+ * + `social-copy-engine` GloryOutputs) as a consumable cockpit surface, instead
+ * of leaving them as dormant JSON in the vault. Read-only projection via
+ * `trpc.glory.launchCalendar`. (Phase 24.)
  */
 
-import { type LucideIcon, CalendarDays, Flag, Radio, Hash, Ban, CheckCircle2, Megaphone, Sparkles } from "lucide-react";
+import { type LucideIcon, CalendarDays, Flag, Radio, Hash, Ban, CheckCircle2, Megaphone, Sparkles, AtSign, Quote, Link2, Star } from "lucide-react";
 import { trpc } from "@/lib/trpc/client";
 import { useCurrentStrategyId } from "@/components/cockpit/strategy-context";
 import { SkeletonPage } from "@/components/shared/loading-skeleton";
-import type { LaunchTimelineWeek } from "@/lib/types/launch-calendar";
+import { CopyButton } from "@/components/shared/copy-button";
+import type { LaunchTimelineWeek, SocialNaming, SocialCopy } from "@/lib/types/launch-calendar";
 
 function isGate(kpi: string): boolean {
   return /gate|go\s*\/\s*no[- ]?go/i.test(kpi);
@@ -29,9 +31,11 @@ export function LaunchCalendarPanel() {
   const data = query.data;
   const timeline = data?.timeline ?? null;
   const calendar = data?.calendar ?? null;
-  const brand = timeline?.brand ?? calendar?.brand ?? "";
+  const naming = data?.naming ?? null;
+  const social = data?.social ?? null;
+  const brand = timeline?.brand ?? calendar?.brand ?? naming?.brandName ?? social?.brand ?? "";
   const generatedAt = data?.generatedAt ? new Date(data.generatedAt) : null;
-  const isEmpty = !query.isLoading && !timeline && !calendar;
+  const isEmpty = !query.isLoading && !timeline && !calendar && !naming && !social;
 
   return (
     <article className="mx-auto max-w-[var(--maxw-content,1200px)] px-[var(--pad-page,1.5rem)] py-8 md:py-12">
@@ -39,14 +43,14 @@ export function LaunchCalendarPanel() {
       <header className="border-b border-border-subtle pb-6 mb-10">
         <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-foreground-muted mb-3">
           <CalendarDays className="h-3.5 w-3.5 text-accent" />
-          <span>Calendrier de prélancement</span>
+          <span>Plan de prélancement digital &amp; social</span>
           {brand ? (<><span className="opacity-50">·</span><span>{brand}</span></>) : null}
         </div>
         <h1 className="font-display font-semibold tracking-tighter leading-[0.95] text-foreground" style={{ fontSize: "var(--text-display)" }}>
           Le plan de lancement.
         </h1>
         <p className="mt-3 text-foreground-secondary max-w-[62ch]" style={{ fontSize: "var(--text-lg)" }}>
-          Produit par les Glory tools <span className="font-mono text-xs text-foreground-muted">launch-timeline-planner</span> + <span className="font-mono text-xs text-foreground-muted">content-calendar-strategist</span>
+          Go-to-market J-ancré, cadence éditoriale, hashtags et présence social — prêts à exécuter
           {generatedAt ? ` · ${generatedAt.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}` : ""}.
         </p>
       </header>
@@ -55,9 +59,9 @@ export function LaunchCalendarPanel() {
 
       {isEmpty ? (
         <div className="rounded-lg border border-dashed border-white/10 bg-white/[0.02] px-6 py-16 text-center">
-          <p className="text-sm text-foreground-secondary">Aucun calendrier de lancement dans le vault.</p>
+          <p className="text-sm text-foreground-secondary">Aucun plan de lancement dans le vault.</p>
           <p className="mt-2 text-xs text-foreground-muted">
-            Lance les Glory tools <strong>launch-timeline-planner</strong> et <strong>content-calendar-strategist</strong> sur cette marque pour générer le plan.
+            Lance les Glory tools <strong>launch-timeline-planner</strong>, <strong>content-calendar-strategist</strong>, <strong>naming-generator</strong> et <strong>social-copy-engine</strong> sur cette marque pour générer le plan.
           </p>
         </div>
       ) : null}
@@ -161,7 +165,121 @@ export function LaunchCalendarPanel() {
           ) : null}
         </section>
       ) : null}
+
+      {/* ═══ Présence social (handles + bios) ═════════════════════ */}
+      {(naming || social) ? (
+        <SocialPresence naming={naming} social={social} />
+      ) : null}
     </article>
+  );
+}
+
+function SocialPresence({ naming, social }: { naming: SocialNaming | null; social: SocialCopy | null }) {
+  return (
+    <section className="mt-16 space-y-12">
+      {/* Comptes recommandés */}
+      {naming && naming.handles.length > 0 ? (
+        <div>
+          <SectionHeader icon={AtSign} label="Comptes recommandés" suffix={`${naming.handles.length} plateformes`} />
+          {naming.handleStrategy ? (
+            <p className="mb-4 text-xs text-foreground-secondary max-w-[72ch]">{naming.handleStrategy}</p>
+          ) : null}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {naming.handles.map((h) => (
+              <div key={h.key} className="flex items-start justify-between gap-3 rounded-lg border border-white/5 bg-surface-raised p-3">
+                <div className="min-w-0">
+                  <div className="font-mono text-[10px] uppercase tracking-widest text-foreground-muted">{h.platform}</div>
+                  <div className="mt-0.5 truncate text-sm font-semibold text-foreground">{h.value}</div>
+                  {h.fallbacks.length > 0 ? (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {h.fallbacks.map((f) => (
+                        <span key={f} className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-foreground-muted">{f}</span>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+                <CopyButton value={h.value} label="" />
+              </div>
+            ))}
+          </div>
+          {naming.availabilityToVerify.length > 0 ? (
+            <p className="mt-3 text-[11px] text-foreground-muted">
+              <span className="font-semibold">À vérifier (dispo)&nbsp;:</span> {naming.availabilityToVerify.join(" · ")}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* Bios par plateforme */}
+      {social && social.profiles.length > 0 ? (
+        <div>
+          <SectionHeader icon={Quote} label="Bios & copy par plateforme" suffix={`${social.profiles.length} profils`} />
+          {social.voice ? (
+            <p className="mb-4 text-xs italic text-foreground-secondary max-w-[72ch]">Voix&nbsp;: {social.voice}</p>
+          ) : null}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {social.profiles.map((p, i) => {
+              const copyText = [p.displayName, p.handle, p.bio ?? p.shortDescription ?? p.about].filter(Boolean).join("\n");
+              return (
+                <div key={`${p.platform}-${i}`} className="rounded-lg border border-white/5 bg-surface-raised p-4">
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <span className="text-sm font-semibold text-foreground">{p.platform}</span>
+                    <div className="flex items-center gap-2">
+                      {p.priority ? <span className="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-foreground-muted">{p.priority}</span> : null}
+                      {copyText ? <CopyButton value={copyText} label="" /> : null}
+                    </div>
+                  </div>
+                  {p.displayName ? <div className="text-xs font-medium text-foreground-secondary">{p.displayName}</div> : null}
+                  {p.handle ? <div className="font-mono text-[11px] text-accent">{p.handle}</div> : null}
+                  {(p.bio ?? p.about ?? p.shortDescription) ? (
+                    <p className="mt-2 whitespace-pre-wrap text-xs text-foreground-secondary leading-relaxed">{p.bio ?? p.about ?? p.shortDescription}</p>
+                  ) : null}
+                  {p.fullDescription ? (
+                    <p className="mt-2 whitespace-pre-wrap text-[11px] text-foreground-muted leading-relaxed">{p.fullDescription}</p>
+                  ) : null}
+                  {p.highlights.length > 0 ? (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {p.highlights.map((h) => (
+                        <span key={h} className="inline-flex items-center gap-1 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] text-accent">
+                          <Star className="h-2.5 w-2.5" />{h}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                  {p.keywords.length > 0 ? (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {p.keywords.map((k) => (
+                        <span key={k} className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-foreground-muted">{k}</span>
+                      ))}
+                    </div>
+                  ) : null}
+                  {(p.pinned || p.contentAngle) ? (
+                    <p className="mt-2 text-[11px] text-foreground-muted">
+                      {p.pinned ? <><span className="font-semibold">Épinglé&nbsp;:</span> {p.pinned}</> : null}
+                      {p.pinned && p.contentAngle ? " · " : null}
+                      {p.contentAngle ? <><span className="font-semibold">Angle&nbsp;:</span> {p.contentAngle}</> : null}
+                    </p>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+
+      {/* Link-in-bio */}
+      {social?.linkInBio?.recommendation ? (
+        <div>
+          <SectionHeader icon={Link2} label="Link-in-bio" />
+          <div className="rounded-lg border border-white/5 bg-surface-raised p-4">
+            <p className="text-xs text-foreground-secondary"><span className="text-accent">→</span> {social.linkInBio.recommendation}</p>
+            {social.linkInBio.avoid ? (
+              <p className="mt-1.5 flex gap-2 text-[11px] text-foreground-muted"><Ban className="mt-0.5 h-3 w-3 shrink-0 text-error" /><span>{social.linkInBio.avoid}</span></p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </section>
   );
 }
 

--- a/src/components/shared/copy-button.tsx
+++ b/src/components/shared/copy-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * CopyButton — tiny shared clipboard action. Operational surfaces (deliverables
+ * hub, launch kit) let the founder copy a handle / bio / hashtag set in one tap.
+ * DS-compliant (semantic tokens only). Degrades silently if the Clipboard API is
+ * unavailable (insecure context) instead of throwing.
+ */
+
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+
+interface CopyButtonProps {
+  value: string;
+  label?: string;
+  className?: string;
+}
+
+export function CopyButton({ value, label = "Copier", className }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      /* clipboard unavailable (insecure context) — no-op */
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={
+        className ??
+        "inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-foreground-muted hover:bg-surface-raised hover:text-foreground-secondary transition-colors"
+      }
+    >
+      {copied ? (
+        <>
+          <Check className="h-3 w-3 text-accent" /> Copié
+        </>
+      ) : (
+        <>
+          <Copy className="h-3 w-3" /> {label}
+        </>
+      )}
+    </button>
+  );
+}

--- a/src/lib/types/launch-calendar.ts
+++ b/src/lib/types/launch-calendar.ts
@@ -23,9 +23,20 @@ export interface LaunchTimelineWeek {
   opsDigitales: string[];
 }
 
+export interface LaunchCheckpoint {
+  at: string;
+  gate: string;
+}
+
 export interface LaunchTimeline {
   brand: string;
   weeks: LaunchTimelineWeek[];
+  /** ISO date of J1 (re-anchorable). Lets the editorial calendar align dated posts. */
+  anchorJ1: string | null;
+  anchorNote: string | null;
+  budgetGtm: string | null;
+  warRoom: string | null;
+  checkpoints: LaunchCheckpoint[];
 }
 
 export interface ContentCadenceChannel {
@@ -40,12 +51,30 @@ export interface ContentCalendarPhase {
   contenus: string[];
 }
 
+/** A single dated publication — the consultable post-by-post editorial calendar. */
+export interface ContentPost {
+  /** ISO date (YYYY-MM-DD). */
+  date: string;
+  /** Localised weekday label (lundi, mardi, …). */
+  weekday: string;
+  /** Launch week label (S1, S2, …) when anchored, else null. */
+  week: string | null;
+  platform: string;
+  format: string | null;
+  theme: string | null;
+  angle: string | null;
+  hashtags: string[];
+  status: string;
+}
+
 export interface ContentCalendar {
   brand: string;
   cadenceParCanal: Record<string, ContentCadenceChannel>;
   themesParPhaseOverton: ContentCalendarPhase[];
   hashtags: { signature: string[]; local: string[] };
   doNot: string[];
+  /** Dated post-by-post calendar. Stored by the deterministic composer, or derived read-side. */
+  posts: ContentPost[];
 }
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
@@ -70,7 +99,21 @@ export function parseLaunchTimeline(raw: unknown): LaunchTimeline | null {
     opsDigitales: strArr(w.opsDigitales),
   }));
   if (weeks.length === 0) return null;
-  return { brand: str(raw.brand) || "Marque", weeks };
+  const anchor = isRecord(raw.anchor) ? raw.anchor : {};
+  const checkpointsRaw = Array.isArray(raw.checkpoints) ? raw.checkpoints : [];
+  const checkpoints: LaunchCheckpoint[] = checkpointsRaw
+    .filter(isRecord)
+    .map((c) => ({ at: str(c.at), gate: str(c.gate) }))
+    .filter((c) => c.at || c.gate);
+  return {
+    brand: str(raw.brand) || "Marque",
+    weeks,
+    anchorJ1: strOrNull(anchor.j1) ?? strOrNull(anchor.J1) ?? strOrNull(anchor.date),
+    anchorNote: strOrNull(anchor.note),
+    budgetGtm: strOrNull(anchor.budgetGtm) ?? strOrNull(raw.budgetGtm),
+    warRoom: strOrNull(raw.warRoom),
+    checkpoints,
+  };
 }
 
 /** Parse the `content-calendar-strategist` output. Returns null if no content. */
@@ -106,7 +149,107 @@ export function parseContentCalendar(raw: unknown): ContentCalendar | null {
     doNot.length > 0;
   if (!hasAny) return null;
 
-  return { brand: str(raw.brand) || "Marque", cadenceParCanal, themesParPhaseOverton, hashtags, doNot };
+  const postsRaw = Array.isArray(raw.posts) ? raw.posts : [];
+  const posts: ContentPost[] = postsRaw.filter(isRecord).map((p) => ({
+    date: str(p.date),
+    weekday: str(p.weekday),
+    week: strOrNull(p.week),
+    platform: str(p.platform) || "Plateforme",
+    format: strOrNull(p.format),
+    theme: strOrNull(p.theme),
+    angle: strOrNull(p.angle),
+    hashtags: strArr(p.hashtags),
+    status: str(p.status) || "PLANIFIE",
+  })).filter((p) => p.date);
+
+  return { brand: str(raw.brand) || "Marque", cadenceParCanal, themesParPhaseOverton, hashtags, doNot, posts };
+}
+
+// ─── Dated posts derivation (pure, deterministic) ────────────────────────────
+
+const WEEKDAYS_FR = ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"];
+// Weekday offsets (0=Mon..6=Sun) for N posts/week — spreads posts sensibly.
+const WEEKDAY_SPREAD: Record<number, number[]> = {
+  1: [3],
+  2: [1, 4],
+  3: [0, 2, 4],
+  4: [0, 1, 3, 4],
+  5: [0, 1, 2, 3, 4],
+  6: [0, 1, 2, 3, 4, 5],
+  7: [0, 1, 2, 3, 4, 5, 6],
+};
+
+/** Extract a posts-per-week integer from a free-text cadence ("4-5 posts/sem" → 4). */
+export function parsePerWeek(rythme: string | null): number {
+  if (!rythme) return 0;
+  const m = rythme.match(/\d+/);
+  if (!m) return 0;
+  const n = parseInt(m[0], 10);
+  return Number.isFinite(n) ? Math.max(0, Math.min(7, n)) : 0;
+}
+
+function toISODate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** Monday on/after the given date (week anchor). */
+function mondayOnAfter(d: Date): Date {
+  const r = new Date(d.getTime());
+  const day = r.getUTCDay(); // 0=Sun..6=Sat
+  const delta = day === 0 ? 1 : day === 1 ? 0 : 8 - day;
+  r.setUTCDate(r.getUTCDate() + delta);
+  return r;
+}
+
+/**
+ * Derive a dated, post-by-post editorial calendar from the channel cadence.
+ * Pure + deterministic for a given `(calendar, anchorISO, weeks)`. Used by the
+ * deterministic composer (stored) and read-side as a fallback when an output
+ * predates the posts[] field.
+ */
+export function deriveDatedPosts(
+  calendar: Pick<ContentCalendar, "cadenceParCanal" | "themesParPhaseOverton" | "hashtags">,
+  anchorISO: string | null,
+  weeks = 4,
+): ContentPost[] {
+  const base = anchorISO ? new Date(`${anchorISO}T00:00:00Z`) : new Date();
+  const anchor = mondayOnAfter(Number.isNaN(base.getTime()) ? new Date() : base);
+
+  const themes: string[] = calendar.themesParPhaseOverton.flatMap((p) => p.contenus);
+  const sig = calendar.hashtags.signature;
+  const posts: ContentPost[] = [];
+
+  for (const [platform, cadence] of Object.entries(calendar.cadenceParCanal)) {
+    const n = parsePerWeek(cadence.rythme);
+    if (n === 0) continue;
+    const offsets = WEEKDAY_SPREAD[n] ?? WEEKDAY_SPREAD[4]!;
+    const angles = [...cadence.piliers, ...cadence.formats];
+    let seq = 0;
+    for (let w = 0; w < weeks; w++) {
+      for (const off of offsets) {
+        const d = new Date(anchor.getTime());
+        d.setUTCDate(d.getUTCDate() + w * 7 + off);
+        const theme = themes.length ? themes[seq % themes.length]! : null;
+        const angle = angles.length ? angles[seq % angles.length]! : cadence.format;
+        posts.push({
+          date: toISODate(d),
+          weekday: WEEKDAYS_FR[d.getUTCDay()]!,
+          week: `S${w + 1}`,
+          platform,
+          format: cadence.format ?? (cadence.formats[0] ?? null),
+          theme,
+          angle: angle ?? null,
+          hashtags: sig.slice(0, 3),
+          status: "PLANIFIE",
+        });
+        seq++;
+      }
+    }
+  }
+
+  // Chronological order, platform-stable within a day.
+  posts.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : a.platform.localeCompare(b.platform)));
+  return posts;
 }
 
 // ─── Social naming (naming-generator) ────────────────────────────────────────

--- a/src/lib/types/launch-calendar.ts
+++ b/src/lib/types/launch-calendar.ts
@@ -1,12 +1,15 @@
 /**
- * Launch calendar — pure types + defensive parsers for the two launch Glory
+ * Launch kit — pure types + defensive parsers for the four launch/social Glory
  * deliverables stored in `GloryOutput.output` (jsonb):
- *   - `launch-timeline-planner`     → retroplanning (weeks J-anchored)
- *   - `content-calendar-strategist` → editorial cadence per channel
+ *   - `launch-timeline-planner`     → retroplanning (weeks J-anchored, GTM)
+ *   - `content-calendar-strategist` → editorial cadence per channel + hashtags
+ *   - `naming-generator`            → recommended social handles + domain
+ *   - `social-copy-engine`          → per-platform bios / display names / copy
  *
- * The cockpit launch-calendar surface reads these via `trpc.glory.launchCalendar`
- * instead of leaving them as dormant JSON in the vault. Parsers are pure and
- * tolerant — a missing/legacy shape yields `null`, never a throw.
+ * The cockpit launch-calendar surface + the deliverables hub read these via
+ * `trpc.glory.launchCalendar` instead of leaving them as dormant JSON in the
+ * vault. Parsers are pure and tolerant — a missing/legacy shape yields `null`,
+ * never a throw.
  */
 
 export interface LaunchTimelineWeek {
@@ -104,4 +107,150 @@ export function parseContentCalendar(raw: unknown): ContentCalendar | null {
   if (!hasAny) return null;
 
   return { brand: str(raw.brand) || "Marque", cadenceParCanal, themesParPhaseOverton, hashtags, doNot };
+}
+
+// ─── Social naming (naming-generator) ────────────────────────────────────────
+
+export interface SocialHandle {
+  /** Humanised platform label (Instagram, TikTok, Domaine, X, …). */
+  platform: string;
+  /** Raw key as stored (instagram, tiktok, domain, …) — stable for ordering. */
+  key: string;
+  value: string;
+  fallbacks: string[];
+}
+
+export interface SocialNaming {
+  brandName: string | null;
+  tagline: string | null;
+  mascot: string | null;
+  handleStrategy: string | null;
+  rationale: string | null;
+  handles: SocialHandle[];
+  doNotName: string[];
+  availabilityToVerify: string[];
+}
+
+const HANDLE_LABELS: Record<string, string> = {
+  instagram: "Instagram",
+  tiktok: "TikTok",
+  facebook: "Facebook",
+  x: "X (Twitter)",
+  twitter: "X (Twitter)",
+  whatsappCommunity: "WhatsApp Community",
+  whatsapp: "WhatsApp",
+  youtube: "YouTube",
+  linkedin: "LinkedIn",
+  domain: "Domaine",
+  googlePlayTitle: "Google Play",
+  appStoreTitle: "App Store",
+};
+
+const humanisePlatform = (key: string): string =>
+  HANDLE_LABELS[key] ?? key.charAt(0).toUpperCase() + key.slice(1).replace(/([A-Z])/g, " $1");
+
+/** Parse the `naming-generator` output. Returns null if no handles + no name. */
+export function parseSocialNaming(raw: unknown): SocialNaming | null {
+  if (!isRecord(raw)) return null;
+
+  const handlesRaw = isRecord(raw.handles) ? raw.handles : {};
+  const fallbacksRaw = isRecord(raw.fallbacks) ? raw.fallbacks : {};
+  const handles: SocialHandle[] = [];
+  for (const [key, v] of Object.entries(handlesRaw)) {
+    const value = str(v);
+    if (!value) continue;
+    handles.push({
+      platform: humanisePlatform(key),
+      key,
+      value,
+      fallbacks: strArr((fallbacksRaw as Record<string, unknown>)[key]),
+    });
+  }
+
+  const brandName = strOrNull(raw.brandName);
+  const tagline = strOrNull(raw.tagline);
+  if (handles.length === 0 && !brandName && !tagline) return null;
+
+  return {
+    brandName,
+    tagline,
+    mascot: strOrNull(raw.mascot),
+    handleStrategy: strOrNull(raw.handleStrategy) ?? strOrNull(raw.handleBaseline),
+    rationale: strOrNull(raw.rationale),
+    handles,
+    doNotName: strArr(raw.doNotName),
+    availabilityToVerify: strArr(raw.availabilityToVerify),
+  };
+}
+
+// ─── Social copy (social-copy-engine) ────────────────────────────────────────
+
+export interface SocialProfile {
+  platform: string;
+  handle: string | null;
+  displayName: string | null;
+  bio: string | null;
+  about: string | null;
+  category: string | null;
+  link: string | null;
+  pinned: string | null;
+  contentAngle: string | null;
+  priority: string | null;
+  highlights: string[];
+  channels: string[];
+  keywords: string[];
+  shortDescription: string | null;
+  fullDescription: string | null;
+}
+
+export interface SocialCopy {
+  brand: string | null;
+  voice: string | null;
+  market: string | null;
+  handleBaseline: string | null;
+  profiles: SocialProfile[];
+  linkInBio: { recommendation: string | null; avoid: string | null } | null;
+  doNot: string[];
+}
+
+/** Parse the `social-copy-engine` output. Returns null if no profiles + no voice. */
+export function parseSocialCopy(raw: unknown): SocialCopy | null {
+  if (!isRecord(raw)) return null;
+
+  const profilesRaw = Array.isArray(raw.profiles) ? raw.profiles : [];
+  const profiles: SocialProfile[] = profilesRaw.filter(isRecord).map((p) => ({
+    platform: str(p.platform) || "Plateforme",
+    handle: strOrNull(p.handle),
+    displayName: strOrNull(p.displayName),
+    bio: strOrNull(p.bio),
+    about: strOrNull(p.about),
+    category: strOrNull(p.category),
+    link: strOrNull(p.link),
+    pinned: strOrNull(p.pinned),
+    contentAngle: strOrNull(p.contentAngle),
+    priority: strOrNull(p.priority),
+    highlights: strArr(p.highlights),
+    channels: strArr(p.channels),
+    keywords: strArr(p.keywords),
+    shortDescription: strOrNull(p.shortDescription),
+    fullDescription: strOrNull(p.fullDescription),
+  }));
+
+  const voice = strOrNull(raw.voice);
+  if (profiles.length === 0 && !voice) return null;
+
+  const linkInBioRaw = isRecord(raw.linkInBio) ? raw.linkInBio : null;
+  const linkInBio = linkInBioRaw
+    ? { recommendation: strOrNull(linkInBioRaw.recommendation), avoid: strOrNull(linkInBioRaw.avoid) }
+    : null;
+
+  return {
+    brand: strOrNull(raw.brand),
+    voice,
+    market: strOrNull(raw.market),
+    handleBaseline: strOrNull(raw.handleBaseline),
+    profiles,
+    linkInBio,
+    doNot: strArr(raw.doNot),
+  };
 }

--- a/src/server/services/artemis/tools/engine.ts
+++ b/src/server/services/artemis/tools/engine.ts
@@ -16,6 +16,7 @@ import type { Prisma } from "@prisma/client";
 import { EXTENDED_GLORY_TOOLS, getGloryTool, getBrandPipelineDependencyOrder, type GloryToolDef } from "./registry";
 import { checkPaidTier, tierGateDenied } from "@/server/services/glory-tools/tier-gate";
 import { invokeExternalTool as anubisInvokeExternalTool } from "@/server/services/anubis/mcp-client";
+import { hasGloryComposer, composeGloryDeterministic } from "./glory-composers";
 
 /**
  * Load full strategy context for enriching GLORY tool prompts.
@@ -176,6 +177,52 @@ export async function executeTool(
   // tier-gateable + chaînables en GlorySequence.
   if (tool.executionType === "DELEGATE" && tool.delegateDescriptor) {
     return executeDelegateTool(tool, strategyId, input, intentEmissionId);
+  }
+
+  // ── Phase 24 — Deterministic ADVERTIS composer (0 LLM) ─────────────────
+  // Si un composer déterministe existe pour ce slug (launch/social), on compose
+  // le livrable depuis les piliers ADVERTIS au lieu d'appeler le LLM : sortie
+  // reproductible, garantie par `outputSchema`, provenance DETERMINISTIC_COMPOSE.
+  // C'est le chemin canonique (ADVERTIS → Glory → GloryOutput) qui faisait défaut.
+  if (hasGloryComposer(tool.slug)) {
+    const composed = await composeGloryDeterministic(tool.slug, strategyId);
+    if (composed.ok) {
+      const aiOutput: Record<string, unknown> = {
+        ...composed.output,
+        _provenance: "DETERMINISTIC_COMPOSE",
+        _meta: {
+          tool: tool.slug,
+          layer: tool.layer,
+          durationMs: 0,
+          deterministic: true,
+          schemaEnforced: Boolean(tool.outputSchema),
+          generatedAt: new Date().toISOString(),
+        },
+      };
+      const gloryOutput = await db.gloryOutput.create({
+        data: {
+          strategyId,
+          toolSlug: tool.slug,
+          output: aiOutput as Prisma.InputJsonValue,
+          advertis_vector: { pillars: tool.pillarKeys },
+        },
+      });
+      if (intentEmissionId) {
+        try {
+          await db.intentEmission.update({
+            where: { id: intentEmissionId },
+            data: {
+              result: { gloryOutputId: gloryOutput.id, status: "OK", deterministic: true } as Prisma.InputJsonValue,
+              completedAt: new Date(),
+            },
+          });
+        } catch {
+          /* best-effort */
+        }
+      }
+      return { outputId: gloryOutput.id, output: aiOutput, intentId: intentEmissionId };
+    }
+    // composed.ok === false (stratégie introuvable) → on laisse filer vers le chemin LLM/legacy.
   }
 
   // Validate inputs — warn on missing fields but don't block execution

--- a/src/server/services/artemis/tools/glory-composers.ts
+++ b/src/server/services/artemis/tools/glory-composers.ts
@@ -1,0 +1,415 @@
+/**
+ * GLORY composers déterministes — launch/social (0 LLM, depuis ADVERTIS).
+ *
+ * Mandat opérateur (galileo) : « dépendre au minimum des LLMs ». Les 4 outils
+ * de prélancement (naming-generator, social-copy-engine, content-calendar-
+ * strategist, launch-timeline-planner) produisent leur livrable en COMPOSANT
+ * les DONNÉES RÉELLES des piliers (A/D/V/E/I/S) dans la shape exacte que les
+ * surfaces cockpit consomment — au lieu de passer par un LLM dont la sortie
+ * n'était pas garantie (cause racine : le script échouait à passer par les
+ * Glory depuis l'ADVERTIS, d'où des outputs écrits à la main).
+ *
+ * Doctrine (Blueprint §3.5, ADR-0091) : COMPOSE = assemblage déterministe,
+ * reproductible, zéro hasard. Aucune invention : un champ pilier absent produit
+ * une lacune (chaîne vide / liste vide), jamais un contenu halluciné.
+ *
+ * Branché dans `executeTool` (engine.ts) AVANT le chemin LLM : si un composer
+ * existe pour le slug → on compose, on valide contre `outputSchema`, on persiste
+ * avec provenance `DETERMINISTIC_COMPOSE`. Reproductible pour TOUTE marque.
+ */
+
+import { db } from "@/lib/db";
+import { deriveDatedPosts, type ContentCalendar } from "@/lib/types/launch-calendar";
+import { LAUNCH_SOCIAL_SCHEMAS } from "./launch-social-schemas";
+
+type Blob = Record<string, unknown>;
+
+export interface GloryComposerContext {
+  strategy: { id: string; name: string; countryCode: string | null; businessContext: Blob | null };
+  pillars: Partial<Record<string, Blob>>;
+}
+
+// ── Helpers purs ────────────────────────────────────────────────────────────
+
+function str(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const t = v.trim();
+  return t.length === 0 ? null : t;
+}
+function arr(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+function strArr(v: unknown): string[] {
+  return arr(v).filter((x): x is string => typeof x === "string" && x.trim().length > 0).map((x) => x.trim());
+}
+function pick(obj: Blob | undefined | null, key: string): unknown {
+  return obj && typeof obj === "object" ? (obj as Blob)[key] : undefined;
+}
+function names(items: unknown[], keys = ["nom", "name", "titre", "title", "action", "valeur", "phase"]): string[] {
+  return items
+    .map((it) => {
+      if (typeof it === "string") return it.trim();
+      if (it && typeof it === "object") {
+        for (const k of keys) {
+          const v = (it as Blob)[k];
+          if (typeof v === "string" && v.trim()) return v.trim();
+        }
+      }
+      return null;
+    })
+    .filter((s): s is string => Boolean(s));
+}
+
+/** Brand display name — first token before a dash/colon separator. "SPAWT — La carte" → "SPAWT". */
+function cleanBrandName(name: string): string {
+  const head = name.split(/\s[—–-]\s|:/)[0]?.trim() || name.trim();
+  return head;
+}
+
+/** URL/handle-safe slug: lowercase, de-accented, alphanumeric, first word only. */
+function slugify(name: string): string {
+  const base = cleanBrandName(name)
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)[0];
+  return base || "brand";
+}
+
+/** "Mon Slogan" → "#MonSlogan" (PascalCase, de-accented, ≤ ~24 chars). */
+function toHashtag(text: string): string {
+  const words = text
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-zA-Z0-9\s]/g, " ")
+    .trim()
+    .split(/\s+/)
+    .slice(0, 3)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1));
+  return "#" + words.join("");
+}
+
+const PLATFORMS: Array<{ key: string; label: string }> = [
+  { key: "instagram", label: "Instagram" },
+  { key: "tiktok", label: "TikTok" },
+  { key: "facebook", label: "Facebook" },
+  { key: "whatsappCommunity", label: "WhatsApp Community" },
+  { key: "x", label: "X (Twitter)" },
+];
+
+// ── Context loader (1 requête) ───────────────────────────────────────────────
+
+export async function loadGloryComposerContext(strategyId: string): Promise<GloryComposerContext | null> {
+  const strategy = await db.strategy.findUnique({
+    where: { id: strategyId },
+    select: {
+      id: true,
+      name: true,
+      countryCode: true,
+      businessContext: true,
+      pillars: { select: { key: true, content: true } },
+    },
+  });
+  if (!strategy) return null;
+  const pillars: Partial<Record<string, Blob>> = {};
+  for (const p of strategy.pillars) pillars[p.key.toLowerCase()] = (p.content ?? {}) as Blob;
+  return {
+    strategy: {
+      id: strategy.id,
+      name: strategy.name,
+      countryCode: strategy.countryCode ?? null,
+      businessContext: (strategy.businessContext ?? null) as Blob | null,
+    },
+    pillars,
+  };
+}
+
+// ── Handle helpers (shared naming/social) ────────────────────────────────────
+
+function buildHandles(ctx: GloryComposerContext) {
+  const slug = slugify(ctx.strategy.name);
+  const cc = (ctx.strategy.countryCode ?? "").toLowerCase().replace(/[^a-z]/g, "");
+  const baseline = cc ? `@${slug}.${cc}` : `@${slug}`;
+  const xHandle = cc ? `@${slug}_${cc}` : `@${slug}`;
+  const domain = cc ? `${slug}.${cc}` : `${slug}.com`;
+  return { slug, cc, baseline, xHandle, domain };
+}
+
+// ── Composer : naming-generator ──────────────────────────────────────────────
+
+export function composeNaming(ctx: GloryComposerContext): Blob {
+  const brandName = cleanBrandName(ctx.strategy.name);
+  const d = ctx.pillars.d ?? {};
+  const ling = (pick(d, "assetsLinguistiques") ?? {}) as Blob;
+  const tagline = str(pick(ling, "slogan")) ?? str(pick(d, "promesseMaitre")) ?? str(pick(ling, "tagline"));
+  const { slug, cc, baseline, xHandle, domain } = buildHandles(ctx);
+
+  const handles: Record<string, string> = {
+    instagram: baseline,
+    tiktok: baseline,
+    facebook: baseline,
+    x: xHandle,
+    whatsappCommunity: `La communauté ${brandName}`,
+    domain,
+    googlePlayTitle: tagline ? `${brandName} — ${tagline}` : brandName,
+  };
+  const fallbacks: Record<string, string[]> = {
+    instagram: cc ? [`@${slug}${cc}`, `@${slug}.app`] : [`@${slug}app`],
+    tiktok: cc ? [`@${slug}${cc}`] : [],
+    domain: [`${slug}.app`, `get${slug}.com`],
+  };
+
+  return {
+    brandName,
+    tagline,
+    mascot: str(pick(d, "mascotte")) ?? null,
+    handleStrategy: `Un seul handle partout pour l'ancrage de marque. Baseline ${baseline}${cc ? ` (le point sépare la marque « ${slug} » du marché « ${cc} », capture-then-grow)` : ""} ; repli @${slug}${cc} (sans point) ; ${xHandle} sur X.`,
+    rationale: `${baseline} ancre la marque${cc ? ` sur ${cc.toUpperCase()}` : ""}, reste court, lisible et identique cross-plateforme pour un rappel maximal.`,
+    handles,
+    fallbacks,
+    doNotName: ["pas de chiffres dans le handle", "pas de tirets", "pas de variations par plateforme (dilue la marque)"],
+    availabilityToVerify: [
+      `instagram.com/${slug}${cc ? "." + cc : ""}`,
+      `tiktok.com/@${slug}${cc ? "." + cc : ""}`,
+      `facebook.com/${slug}${cc ? "." + cc : ""}`,
+      `whois ${domain}`,
+    ],
+  };
+}
+
+// ── Composer : social-copy-engine ────────────────────────────────────────────
+
+export function composeSocialCopy(ctx: GloryComposerContext): Blob {
+  const brandName = cleanBrandName(ctx.strategy.name);
+  const d = ctx.pillars.d ?? {};
+  const e = ctx.pillars.e ?? {};
+  const a = ctx.pillars.a ?? {};
+  const ton = (pick(d, "tonDeVoix") ?? {}) as Blob;
+  const ling = (pick(d, "assetsLinguistiques") ?? {}) as Blob;
+  const personnalite = strArr(pick(ton, "personnalite"));
+  const onNeDitPas = strArr(pick(ton, "onNeDitPas"));
+  const slogan = str(pick(ling, "slogan"));
+  const lexique = strArr(pick(ling, "lexique"));
+  const promesse = str(pick(d, "promesseMaitre")) ?? str(pick(d, "positionnement"));
+  const elevator = str(pick(a, "originMythElevator")) ?? str(pick(a, "noyauIdentitaire"));
+  const rituels = names(arr(pick(e, "rituels")));
+  const sector = str(pick(ctx.strategy.businessContext, "sector"));
+  const country = str(pick(ctx.strategy.businessContext, "country")) ?? (ctx.strategy.countryCode ?? null);
+  const { baseline, xHandle, domain } = buildHandles(ctx);
+  const link = `https://${domain}`;
+
+  const voice = personnalite.length ? `${personnalite.join(", ")}.` : null;
+  const highlights = (lexique.length ? lexique : rituels).slice(0, 5);
+  const displayName = slogan ? `${brandName} · ${slogan}` : brandName;
+  const bioBase = [slogan, promesse].filter(Boolean).join(" — ");
+
+  const profiles: Blob[] = [
+    {
+      platform: "Instagram",
+      handle: baseline,
+      displayName,
+      bio: [slogan, promesse, "👇 Découvre-nous"].filter(Boolean).join("\n"),
+      link,
+      pinned: "Reel manifeste → CTA principal",
+      category: sector ? `Application — ${sector}` : "Marque",
+      highlights,
+    },
+    {
+      platform: "TikTok",
+      handle: baseline,
+      displayName: brandName,
+      bio: bioBase || promesse || slogan,
+      link,
+      contentAngle: "UGC natif + voix de marque, jamais studio",
+    },
+    {
+      platform: "WhatsApp Community",
+      handle: "lien d'invitation",
+      displayName: `La communauté ${brandName}`,
+      bio: promesse ? `${promesse} — chaque semaine, l'essentiel partagé par la communauté.` : `La communauté ${brandName}.`,
+      channels: ["📣 Annonces", "🍽️ Partages de la communauté"],
+    },
+    {
+      platform: "Facebook",
+      handle: baseline,
+      displayName,
+      bio: promesse || bioBase,
+      about: elevator,
+      category: "Page",
+    },
+    {
+      platform: "X (Twitter)",
+      handle: xHandle,
+      displayName: brandName,
+      bio: [slogan, promesse].filter(Boolean).join(". "),
+      priority: "secondaire",
+    },
+  ];
+
+  return {
+    brand: ctx.strategy.name,
+    voice,
+    market: [country, sector].filter(Boolean).join(" · ") || null,
+    handleBaseline: baseline,
+    profiles,
+    linkInBio: {
+      recommendation: `un seul lien = la landing principale (${domain}) qui capte le lead`,
+      avoid: "linktree générique qui dilue le CTA",
+    },
+    doNot: onNeDitPas.map((x) => `ne pas dire « ${x} »`),
+  };
+}
+
+// ── Composer : content-calendar-strategist ───────────────────────────────────
+
+function launchAnchorISO(ctx: GloryComposerContext): string | null {
+  const s = ctx.pillars.s ?? {};
+  const bc = ctx.strategy.businessContext ?? {};
+  return (
+    str(pick(bc, "launchDate")) ??
+    str(pick(s, "launchDate")) ??
+    str(pick((pick(s, "computed") ?? {}) as Blob, "launchDate")) ??
+    null
+  );
+}
+
+export function composeContentCalendar(ctx: GloryComposerContext): Blob {
+  const brandName = cleanBrandName(ctx.strategy.name);
+  const d = ctx.pillars.d ?? {};
+  const e = ctx.pillars.e ?? {};
+  const i = ctx.pillars.i ?? {};
+  const ling = (pick(d, "assetsLinguistiques") ?? {}) as Blob;
+  const ton = (pick(d, "tonDeVoix") ?? {}) as Blob;
+  const slogan = str(pick(ling, "slogan"));
+  const lexique = strArr(pick(ling, "lexique"));
+  const formats = strArr(pick(i, "formatsDisponibles"));
+  const rituels = names(arr(pick(e, "rituels")));
+  const assets = names(arr(pick(i, "assetsProduisibles")), ["asset", "name", "nom"]);
+  const sector = str(pick(ctx.strategy.businessContext, "sector"));
+  const country = str(pick(ctx.strategy.businessContext, "country")) ?? (ctx.strategy.countryCode ?? null);
+
+  const piliers = (rituels.length ? rituels : lexique).slice(0, 4);
+  const cadenceParCanal: ContentCalendar["cadenceParCanal"] = {
+    Instagram: { rythme: "4-5 posts/sem + stories quotidiennes", piliers, formats, format: null },
+    TikTok: { rythme: "3-4 vidéos/sem", piliers: [], formats: formats.length ? formats : ["UGC natif", "format court"], format: null },
+    Facebook: { rythme: "2 posts/sem", piliers: [], formats: [], format: "reprise IG + communauté locale" },
+    "WhatsApp Community": { rythme: "1 digest / semaine", piliers: [], formats: [], format: "digest hebdomadaire (jamais un classement)" },
+  };
+
+  // Overton phases canon (Révéler → Prouver → Normaliser) garnies de données réelles.
+  const themesParPhaseOverton = [
+    { phase: "Révéler", contenus: [slogan, rituels[0], assets[0]].filter((x): x is string => Boolean(x)) },
+    { phase: "Prouver", contenus: [...rituels.slice(1, 3), ...assets.slice(1, 2)].filter(Boolean) },
+    { phase: "Normaliser", contenus: [...assets.slice(2), ...formats.slice(0, 2)].filter(Boolean) },
+  ].filter((p) => p.contenus.length > 0);
+
+  const signature = [
+    slogan ? toHashtag(slogan) : null,
+    toHashtag(brandName),
+    ...lexique.slice(0, 1).map(toHashtag),
+  ].filter((x): x is string => Boolean(x));
+  const local = [
+    country ? `#${country.replace(/\s+/g, "")}` : null,
+    sector && country ? `#${sector.replace(/\s+/g, "")}${country.replace(/\s+/g, "")}` : null,
+  ].filter((x): x is string => Boolean(x));
+
+  const calForPosts = { cadenceParCanal, themesParPhaseOverton, hashtags: { signature, local } };
+  const posts = deriveDatedPosts(calForPosts, launchAnchorISO(ctx), 4);
+
+  return {
+    brand: ctx.strategy.name,
+    cadenceParCanal,
+    themesParPhaseOverton,
+    hashtags: { signature, local },
+    doNot: strArr(pick(ton, "onNeDitPas")),
+    posts,
+  };
+}
+
+// ── Composer : launch-timeline-planner ───────────────────────────────────────
+
+export function composeLaunchTimeline(ctx: GloryComposerContext): Blob {
+  const s = ctx.pillars.s ?? {};
+  const i = ctx.pillars.i ?? {};
+  const roadmap = arr(pick(s, "roadmap")).filter((x): x is Blob => typeof x === "object" && x !== null);
+  const catalogue = (pick(i, "catalogueParCanal") ?? {}) as Blob;
+  const canaux = Object.keys(catalogue);
+
+  const weeks = roadmap.map((ph, idx) => ({
+    semaine: `S${idx + 1}`,
+    dates: str(pick(ph, "duree")) ?? `Phase ${idx + 1}`,
+    phase: str(pick(ph, "phase")) ?? `Phase ${idx + 1}`,
+    theme: str(pick(ph, "objectifDevotion")) ?? str(pick(ph, "objectif")) ?? "",
+    kpi: str(pick(ph, "objectif")) ?? "",
+    canaux,
+    actions: strArr(pick(ph, "actions")),
+    opsDigitales: [],
+  }));
+
+  const checkpoints = roadmap
+    .map((ph) => ({ at: str(pick(ph, "duree")) ?? "", gate: str(pick(ph, "objectif")) ?? "" }))
+    .filter((c) => c.at || c.gate);
+
+  return {
+    brand: ctx.strategy.name,
+    weeks,
+    anchor: {
+      j1: launchAnchorISO(ctx),
+      note: "Calendrier relatif — re-ancrable. Si la date de départ bouge, décale tout le bloc.",
+      budgetGtm: str(pick(s, "globalBudget")),
+    },
+    warRoom: "Revue hebdomadaire des indicateurs clés du lancement.",
+    checkpoints,
+  };
+}
+
+// ── Registry + dispatch ──────────────────────────────────────────────────────
+
+const GLORY_COMPOSERS: Record<string, (ctx: GloryComposerContext) => Blob> = {
+  "naming-generator": composeNaming,
+  "social-copy-engine": composeSocialCopy,
+  "content-calendar-strategist": composeContentCalendar,
+  "launch-timeline-planner": composeLaunchTimeline,
+};
+
+/** True si un composer déterministe existe pour ce slug. */
+export function hasGloryComposer(slug: string): boolean {
+  return slug in GLORY_COMPOSERS;
+}
+
+export interface DeterministicGloryResult {
+  output: Blob;
+  /** false si la stratégie est introuvable — caller décide du fallback. */
+  ok: boolean;
+}
+
+/**
+ * Compose le livrable déterministe d'un Glory tool depuis l'ADVERTIS.
+ * Valide contre `outputSchema` (safe — on retourne la sortie composer même si
+ * la validation signale un écart, mais on logge). 0 LLM, 0 réseau hors DB.
+ */
+export async function composeGloryDeterministic(
+  slug: string,
+  strategyId: string,
+): Promise<DeterministicGloryResult> {
+  const composer = GLORY_COMPOSERS[slug];
+  if (!composer) return { output: {}, ok: false };
+
+  const ctx = await loadGloryComposerContext(strategyId);
+  if (!ctx) return { output: {}, ok: false };
+
+  const raw = composer(ctx);
+
+  const schema = LAUNCH_SOCIAL_SCHEMAS[slug as keyof typeof LAUNCH_SOCIAL_SCHEMAS];
+  if (schema) {
+    const parsed = schema.safeParse(raw);
+    if (!parsed.success) {
+      console.warn(`[glory-composers] ${slug}: composer output failed schema —`, parsed.error.issues.slice(0, 3));
+    } else {
+      return { output: parsed.data as Blob, ok: true };
+    }
+  }
+  return { output: raw, ok: true };
+}

--- a/src/server/services/artemis/tools/launch-social-schemas.ts
+++ b/src/server/services/artemis/tools/launch-social-schemas.ts
@@ -1,0 +1,119 @@
+/**
+ * Output schemas (Zod) for the 4 launch/social Glory tools.
+ *
+ * These lock the contract for the deterministic ADVERTIS composers
+ * (`glory-composers.ts`) AND serve as `outputSchema` on the tool registry
+ * entries — so the canonical `executeTool` path is schema-enforced whether the
+ * output comes from a composer (validated here) or, absent a composer, the LLM
+ * fallback (ADR-0067 `executeStructuredLLMCall`).
+ *
+ * Kept dependency-free (zod only) so `registry.ts` can import without pulling in
+ * the db-backed composer module.
+ */
+
+import { z } from "zod";
+
+export const namingOutputSchema = z.object({
+  brandName: z.string(),
+  tagline: z.string().nullable().optional(),
+  mascot: z.string().nullable().optional(),
+  handleStrategy: z.string().nullable().optional(),
+  rationale: z.string().nullable().optional(),
+  handles: z.record(z.string(), z.string()),
+  fallbacks: z.record(z.string(), z.array(z.string())).optional(),
+  doNotName: z.array(z.string()),
+  availabilityToVerify: z.array(z.string()),
+});
+
+export const socialProfileSchema = z.object({
+  platform: z.string(),
+  handle: z.string().nullable().optional(),
+  displayName: z.string().nullable().optional(),
+  bio: z.string().nullable().optional(),
+  about: z.string().nullable().optional(),
+  category: z.string().nullable().optional(),
+  link: z.string().nullable().optional(),
+  pinned: z.string().nullable().optional(),
+  contentAngle: z.string().nullable().optional(),
+  priority: z.string().nullable().optional(),
+  highlights: z.array(z.string()).optional(),
+  channels: z.array(z.string()).optional(),
+  keywords: z.array(z.string()).optional(),
+  shortDescription: z.string().nullable().optional(),
+  fullDescription: z.string().nullable().optional(),
+});
+
+export const socialCopyOutputSchema = z.object({
+  brand: z.string(),
+  voice: z.string().nullable().optional(),
+  market: z.string().nullable().optional(),
+  handleBaseline: z.string().nullable().optional(),
+  profiles: z.array(socialProfileSchema),
+  linkInBio: z
+    .object({ recommendation: z.string().nullable(), avoid: z.string().nullable() })
+    .nullable()
+    .optional(),
+  doNot: z.array(z.string()),
+});
+
+export const contentPostSchema = z.object({
+  date: z.string(),
+  weekday: z.string(),
+  week: z.string().nullable().optional(),
+  platform: z.string(),
+  format: z.string().nullable().optional(),
+  theme: z.string().nullable().optional(),
+  angle: z.string().nullable().optional(),
+  hashtags: z.array(z.string()),
+  status: z.string(),
+});
+
+export const contentCalendarOutputSchema = z.object({
+  brand: z.string(),
+  cadenceParCanal: z.record(
+    z.string(),
+    z.object({
+      rythme: z.string().nullable().optional(),
+      piliers: z.array(z.string()).optional(),
+      formats: z.array(z.string()).optional(),
+      format: z.string().nullable().optional(),
+    }),
+  ),
+  themesParPhaseOverton: z.array(z.object({ phase: z.string(), contenus: z.array(z.string()) })),
+  hashtags: z.object({ signature: z.array(z.string()), local: z.array(z.string()) }),
+  doNot: z.array(z.string()),
+  posts: z.array(contentPostSchema),
+});
+
+export const launchTimelineWeekSchema = z.object({
+  semaine: z.string(),
+  dates: z.string(),
+  phase: z.string(),
+  theme: z.string(),
+  kpi: z.string(),
+  canaux: z.array(z.string()),
+  actions: z.array(z.string()),
+  opsDigitales: z.array(z.string()),
+});
+
+export const launchTimelineOutputSchema = z.object({
+  brand: z.string(),
+  weeks: z.array(launchTimelineWeekSchema),
+  anchor: z
+    .object({
+      j1: z.string().nullable().optional(),
+      note: z.string().nullable().optional(),
+      budgetGtm: z.string().nullable().optional(),
+    })
+    .optional(),
+  warRoom: z.string().nullable().optional(),
+  checkpoints: z.array(z.object({ at: z.string(), gate: z.string() })).optional(),
+});
+
+/** slug → schema. Single source for both the registry and the composers. */
+export const LAUNCH_SOCIAL_SCHEMAS = {
+  "naming-generator": namingOutputSchema,
+  "social-copy-engine": socialCopyOutputSchema,
+  "content-calendar-strategist": contentCalendarOutputSchema,
+  "launch-timeline-planner": launchTimelineOutputSchema,
+} as const;

--- a/src/server/services/artemis/tools/registry.ts
+++ b/src/server/services/artemis/tools/registry.ts
@@ -1,5 +1,11 @@
 import { ADVE_KEYS } from "@/domain";
 import { z } from "zod";
+import {
+  namingOutputSchema,
+  socialCopyOutputSchema,
+  contentCalendarOutputSchema,
+  launchTimelineOutputSchema,
+} from "./launch-social-schemas";
 
 /**
  * GLORY Tools — Atomic Creative Operations Registry
@@ -226,6 +232,7 @@ Livrable : layout description, headline, body copy, CTA, indications visuelles.`
       tone: "d.tonDeVoix.personnalite",
     },
     outputFormat: "social_copy_set",
+    outputSchema: socialCopyOutputSchema,
     promptTemplate: `Adapte le copy pour {{platform}} ({{content_type}}) :
 Sujet : {{topic}} | Ton : {{tone}}
 Stratégie hashtags : {{hashtags_strategy}}
@@ -857,6 +864,7 @@ Format : ligne par ligne avec description, quantité, prix unitaire, total, cond
       events: "e.sacredCalendar",
     },
     outputFormat: "content_calendar",
+    outputSchema: contentCalendarOutputSchema,
     promptTemplate: `Calendrier éditorial sur {{duration}} :
 Plateformes : {{platforms}} | Fréquence : {{frequency}}
 Thèmes : {{themes}} | Événements clés : {{events}}
@@ -2255,6 +2263,7 @@ Livrable : score readability, structure Hn recommandée, méta title/description
       cultural_context: "a.doctrine",
     },
     outputFormat: "name_proposals",
+    outputSchema: namingOutputSchema,
     promptTemplate: `Naming :
 ADN : {{brand_dna}} | Valeurs : {{values}}
 Contexte culturel : {{cultural_context}}
@@ -2405,6 +2414,7 @@ Livrable : répartition ATL/BTL/Digital (%), allocation par canal, GRP cibles, C
       roadmap: "s.roadmap",
     },
     outputFormat: "launch_timeline",
+    outputSchema: launchTimelineOutputSchema,
     promptTemplate: `Timeline lancement :
 Date J : {{launch_date}}
 Architecture campagne : {{campaign_architecture}}

--- a/src/server/trpc/routers/glory.ts
+++ b/src/server/trpc/routers/glory.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure, operatorProcedure } from "../init";
 import * as gloryTools from "@/server/services/glory-tools";
 import { governedProcedure } from "@/server/governance/governed-procedure";
-import { parseLaunchTimeline, parseContentCalendar } from "@/lib/types/launch-calendar";
+import { parseLaunchTimeline, parseContentCalendar, parseSocialNaming, parseSocialCopy } from "@/lib/types/launch-calendar";
 import { estimateSequenceCost } from "@/server/services/artemis/tools/sequence-cost";
 /* lafusee:governed-active */
 
@@ -431,28 +431,42 @@ export const gloryRouter = createTRPCRouter({
       };
     }),
 
-  // ── Launch calendar (Phase 24) — surface the launch-timeline-planner +
-  //    content-calendar-strategist GloryOutputs as a typed, renderable plan
-  //    instead of dormant vault JSON. Pure read, tenant-scoped via ctx.db.
+  // ── Launch kit (Phase 24) — surface the launch/social GloryOutputs as a
+  //    typed, renderable plan instead of dormant vault JSON. Four standalone
+  //    deliverables (GTM timeline, editorial calendar, recommended handles,
+  //    per-platform social copy) consumed by both the launch-calendar surface
+  //    and the operational deliverables hub. Pure read, tenant-scoped via ctx.db.
   launchCalendar: protectedProcedure
     .input(z.object({ strategyId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const rows = await ctx.db.gloryOutput.findMany({
         where: {
           strategyId: input.strategyId,
-          toolSlug: { in: ["launch-timeline-planner", "content-calendar-strategist"] },
+          toolSlug: {
+            in: [
+              "launch-timeline-planner",
+              "content-calendar-strategist",
+              "naming-generator",
+              "social-copy-engine",
+            ],
+          },
         },
         orderBy: { createdAt: "desc" },
         select: { toolSlug: true, output: true, createdAt: true },
       });
-      const timelineRow = rows.find((r) => r.toolSlug === "launch-timeline-planner");
-      const calendarRow = rows.find((r) => r.toolSlug === "content-calendar-strategist");
-      const generatedAt = [timelineRow?.createdAt, calendarRow?.createdAt]
+      const pick = (slug: string) => rows.find((r) => r.toolSlug === slug);
+      const timelineRow = pick("launch-timeline-planner");
+      const calendarRow = pick("content-calendar-strategist");
+      const namingRow = pick("naming-generator");
+      const socialRow = pick("social-copy-engine");
+      const generatedAt = [timelineRow?.createdAt, calendarRow?.createdAt, namingRow?.createdAt, socialRow?.createdAt]
         .filter((d): d is Date => d instanceof Date)
         .sort((a, b) => b.getTime() - a.getTime())[0] ?? null;
       return {
         timeline: parseLaunchTimeline(timelineRow?.output ?? null),
         calendar: parseContentCalendar(calendarRow?.output ?? null),
+        naming: parseSocialNaming(namingRow?.output ?? null),
+        social: parseSocialCopy(socialRow?.output ?? null),
         generatedAt: generatedAt ? generatedAt.toISOString() : null,
       };
     }),

--- a/src/server/trpc/routers/glory.ts
+++ b/src/server/trpc/routers/glory.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure, operatorProcedure } from "../init";
 import * as gloryTools from "@/server/services/glory-tools";
 import { governedProcedure } from "@/server/governance/governed-procedure";
-import { parseLaunchTimeline, parseContentCalendar, parseSocialNaming, parseSocialCopy } from "@/lib/types/launch-calendar";
+import { parseLaunchTimeline, parseContentCalendar, parseSocialNaming, parseSocialCopy, deriveDatedPosts } from "@/lib/types/launch-calendar";
 import { estimateSequenceCost } from "@/server/services/artemis/tools/sequence-cost";
 /* lafusee:governed-active */
 
@@ -462,9 +462,19 @@ export const gloryRouter = createTRPCRouter({
       const generatedAt = [timelineRow?.createdAt, calendarRow?.createdAt, namingRow?.createdAt, socialRow?.createdAt]
         .filter((d): d is Date => d instanceof Date)
         .sort((a, b) => b.getTime() - a.getTime())[0] ?? null;
+
+      const timeline = parseLaunchTimeline(timelineRow?.output ?? null);
+      const calendar = parseContentCalendar(calendarRow?.output ?? null);
+      // Read-side fallback: outputs predating the posts[] field (or hand-written
+      // deterministic seeds) get a dated post-by-post calendar derived from their
+      // cadence, anchored on the launch timeline J1. Pure + deterministic.
+      if (calendar && calendar.posts.length === 0) {
+        calendar.posts = deriveDatedPosts(calendar, timeline?.anchorJ1 ?? null, 4);
+      }
+
       return {
-        timeline: parseLaunchTimeline(timelineRow?.output ?? null),
-        calendar: parseContentCalendar(calendarRow?.output ?? null),
+        timeline,
+        calendar,
         naming: parseSocialNaming(namingRow?.output ?? null),
         social: parseSocialCopy(socialRow?.output ?? null),
         generatedAt: generatedAt ? generatedAt.toISOString() : null,

--- a/tests/unit/services/glory-composers.test.ts
+++ b/tests/unit/services/glory-composers.test.ts
@@ -1,0 +1,168 @@
+/**
+ * glory-composers.test.ts — pipeline canonique déterministe launch/social.
+ *
+ * Vérifie que les 4 composers ADVERTIS (0 LLM) produisent, depuis les piliers,
+ * la shape exacte garantie par `outputSchema` + les invariants attendus par les
+ * surfaces cockpit (handles cross-plateforme, bios, calendrier daté, timeline).
+ * Pur — aucun accès DB (les composers prennent un contexte injecté).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  composeNaming,
+  composeSocialCopy,
+  composeContentCalendar,
+  composeLaunchTimeline,
+  hasGloryComposer,
+  type GloryComposerContext,
+} from "@/server/services/artemis/tools/glory-composers";
+import {
+  namingOutputSchema,
+  socialCopyOutputSchema,
+  contentCalendarOutputSchema,
+  launchTimelineOutputSchema,
+  LAUNCH_SOCIAL_SCHEMAS,
+} from "@/server/services/artemis/tools/launch-social-schemas";
+
+// Fixture fidèle aux shapes réelles du canon SPAWT (champs piliers réels).
+const SPAWT: GloryComposerContext = {
+  strategy: {
+    id: "spawt-strategy-001",
+    name: "SPAWT — La carte du bon goût",
+    countryCode: "CI",
+    businessContext: { sector: "FoodTech", country: "Côte d'Ivoire", launchDate: "2026-06-15" },
+  },
+  pillars: {
+    a: {
+      noyauIdentitaire: "Le compagnon culinaire d'Abidjan",
+      originMythElevator: "Né d'un ras-le-bol des 47 messages WhatsApp pour choisir où manger.",
+      valeurs: [{ valeur: "Instinct" }, { valeur: "Communauté" }],
+    },
+    d: {
+      positionnement: "Le compagnon de découverte culinaire communautaire d'Abidjan.",
+      promesseMaitre: "Plus jamais le goumin d'un mauvais restau.",
+      tonDeVoix: {
+        personnalite: ["Complice", "Curieux", "Indépendant"],
+        onDit: ["spawter", "trouvaille", "la Meute"],
+        onNeDitPas: ["classement", "top 10", "le meilleur resto"],
+      },
+      assetsLinguistiques: {
+        slogan: "La carte du bon goût",
+        tagline: "On ne te dit pas quoi manger.",
+        lexique: ["spawter", "la Meute", "le Chat", "Palais"],
+      },
+    },
+    e: {
+      rituels: [
+        { nom: "Le Weekly Digest", frequence: "hebdomadaire", description: "3 trouvailles de la Meute" },
+        { nom: "Le quiz Palais", frequence: "onboarding", description: "5 questions → archétype" },
+        { nom: "La première trouvaille", frequence: "une fois", description: "premier spawt < 3 min" },
+      ],
+    },
+    i: {
+      formatsDisponibles: ["quiz interactif", "carte archétype", "UGC créateurs"],
+      assetsProduisibles: [
+        { asset: "Carte archétype partageable", type: "SOCIAL" },
+        { asset: "Manifeste vidéo", type: "VIDEO" },
+        { asset: "Weekly Digest", type: "ÉDITORIAL" },
+      ],
+      catalogueParCanal: {
+        DIGITAL: [{ id: "A1", action: "Landing + Quiz Palais" }],
+        SOCIAL: [{ id: "A3", action: "Micro-créateurs food" }],
+      },
+    },
+    s: {
+      globalBudget: "1 000 000 FCFA",
+      roadmap: [
+        { phase: "Phase 1 — Construire (J1-J30)", objectif: "1 500 leads, 20 lieux", objectifDevotion: "1 500 SPECTATEURS", actions: ["A1 landing", "A4 terrain B2B"], budget: 405000, duree: "1 mois" },
+        { phase: "Phase 2 — Lancer (J31-J60)", objectif: "CPA ≤ 200 F, J7 ≥ 25 %", objectifDevotion: "Gate Scale", actions: ["A7 paid UGC", "A8 referral"], budget: 300000, duree: "1 mois" },
+      ],
+    },
+  },
+};
+
+const EMPTY: GloryComposerContext = {
+  strategy: { id: "x", name: "Acme", countryCode: null, businessContext: null },
+  pillars: {},
+};
+
+describe("glory-composers — registry", () => {
+  it("couvre exactement les 4 outils launch/social", () => {
+    for (const slug of ["naming-generator", "social-copy-engine", "content-calendar-strategist", "launch-timeline-planner"]) {
+      expect(hasGloryComposer(slug), `composer manquant: ${slug}`).toBe(true);
+      expect(LAUNCH_SOCIAL_SCHEMAS[slug as keyof typeof LAUNCH_SOCIAL_SCHEMAS]).toBeDefined();
+    }
+    expect(hasGloryComposer("concept-generator")).toBe(false);
+  });
+});
+
+describe("composeNaming", () => {
+  const out = composeNaming(SPAWT);
+  it("valide le schéma", () => expect(namingOutputSchema.safeParse(out).success).toBe(true));
+  it("ancre les handles sur la marque × marché (capture-then-grow)", () => {
+    const h = out.handles as Record<string, string>;
+    expect(h.instagram).toBe("@spawt.ci");
+    expect(h.tiktok).toBe("@spawt.ci");
+    expect(h.x).toBe("@spawt_ci"); // point interdit sur X
+    expect(h.domain).toBe("spawt.ci");
+    expect(out.brandName).toBe("SPAWT");
+    expect(out.tagline).toBe("La carte du bon goût");
+  });
+  it("est honnête sur pilier vide (pas de throw, slug fallback)", () => {
+    const e = composeNaming(EMPTY);
+    expect(namingOutputSchema.safeParse(e).success).toBe(true);
+    expect((e.handles as Record<string, string>).instagram).toBe("@acme");
+  });
+});
+
+describe("composeSocialCopy", () => {
+  const out = composeSocialCopy(SPAWT);
+  it("valide le schéma", () => expect(socialCopyOutputSchema.safeParse(out).success).toBe(true));
+  it("produit un profil par plateforme avec handle + bio", () => {
+    const profiles = out.profiles as Array<Record<string, unknown>>;
+    expect(profiles.length).toBe(5);
+    const ig = profiles.find((p) => p.platform === "Instagram")!;
+    expect(ig.handle).toBe("@spawt.ci");
+    expect(typeof ig.bio).toBe("string");
+    expect(out.voice).toContain("Complice");
+  });
+});
+
+describe("composeContentCalendar", () => {
+  const out = composeContentCalendar(SPAWT);
+  it("valide le schéma", () => expect(contentCalendarOutputSchema.safeParse(out).success).toBe(true));
+  it("dérive des hashtags depuis le slogan + la marque", () => {
+    const sig = (out.hashtags as { signature: string[] }).signature;
+    expect(sig).toContain("#SPAWT");
+    expect(sig.some((h) => h.startsWith("#LaCarte"))).toBe(true);
+  });
+  it("génère un calendrier de publication daté (posts un-par-un)", () => {
+    const posts = out.posts as Array<Record<string, unknown>>;
+    expect(posts.length).toBeGreaterThan(0);
+    for (const p of posts) expect(p.date as string).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // J1 = lundi 2026-06-15 → premier post le 15 (Instagram avant TikTok, tri stable).
+    expect(posts[0]!.date).toBe("2026-06-15");
+    expect(posts.some((p) => p.platform === "Instagram")).toBe(true);
+    expect(posts.every((p) => p.status === "PLANIFIE")).toBe(true);
+  });
+});
+
+describe("composeLaunchTimeline", () => {
+  const out = composeLaunchTimeline(SPAWT);
+  it("valide le schéma", () => expect(launchTimelineOutputSchema.safeParse(out).success).toBe(true));
+  it("mappe la roadmap S en semaines + ancre le budget GTM", () => {
+    const weeks = out.weeks as Array<Record<string, unknown>>;
+    expect(weeks.length).toBe(2);
+    expect(weeks[0]!.phase).toContain("Phase 1");
+    expect((out.anchor as Record<string, unknown>).budgetGtm).toBe("1 000 000 FCFA");
+    expect((out.checkpoints as unknown[]).length).toBe(2);
+  });
+});
+
+describe("déterminisme (variance 0)", () => {
+  it("même contexte → sortie identique", () => {
+    expect(JSON.stringify(composeNaming(SPAWT))).toBe(JSON.stringify(composeNaming(SPAWT)));
+    expect(JSON.stringify(composeContentCalendar(SPAWT))).toBe(JSON.stringify(composeContentCalendar(SPAWT)));
+    expect(JSON.stringify(composeLaunchTimeline(SPAWT))).toBe(JSON.stringify(composeLaunchTimeline(SPAWT)));
+  });
+});


### PR DESCRIPTION
## Contexte

La marque **SPAWT** avait généré son prélancement, mais le **planning digital**, les **tags / handles social recommandés** et le **plan Go-to-market** n'étaient pas visibles. Audit : les 4 GloryOutput (`launch-timeline-planner`, `content-calendar-strategist`, `naming-generator`, `social-copy-engine`) étaient bien en base, mais (1) comptes + bios social surfacés nulle part, (2) absents de la section Livrables, (3) produits hors process canonique (écrits à la main faute d'`outputSchema` sur les Glory tools).

## Ce que fait la PR (2 commits)

### `87b91de` — surfaçage opérationnel
- `parseSocialNaming` + `parseSocialCopy` (purs, défensifs) dans `launch-calendar.ts`.
- `glory.launchCalendar` lit les **4** slugs → `{ timeline, calendar, naming, social }`.
- `/cockpit/operate/calendar` : section **Présence social** (comptes + replis, bios/copy par plateforme avec copie, link-in-bio).
- **Réorganisation `/cockpit/brand/deliverables` en hub opérationnel** : catégorie *Opérationnel — lancement, contenu & social* (cartes Plan de lancement GTM · Calendrier éditorial + copie hashtags · Kit social + copie comptes), *Documents compilables*, *Raccourcis*.
- `CopyButton` partagé DS-compliant.

### `c906042` — pipeline canonique déterministe (0 LLM)
- **Composers déterministes** `glory-composers.ts` : 4 composers qui assemblent handles / bios / cadence / timeline depuis les piliers **A/D/V/E/I/S**. Branchés dans `executeTool` **avant** le LLM (provenance `DETERMINISTIC_COMPOSE`). Reproductible pour toute marque, sans clé LLM.
- **`outputSchema` (Zod)** sur les 4 tools (`launch-social-schemas.ts`) — contrat verrouillé.
- **Posts datés un-par-un** : `ContentPost` + `deriveDatedPosts` (pur) — calendrier de publication daté (date / jour / plateforme / thème / angle / hashtags / statut), produit par le composer **ou** dérivé read-time depuis la cadence (les outputs antérieurs en bénéficient sans re-run).
- `/cockpit/operate/calendar` : section **Calendrier de publication** (posts groupés par semaine).

## Vérification

- `tsc --noEmit` **0** · `eslint` **0** · **817 tests gouvernance + 12 tests composers** verts.
- Dérivation vérifiée sur la cadence réelle SPAWT : 40 posts datés (10/sem × 4), ancrés J1 = lundi 15 juin, Weekly Digest WhatsApp le jeudi.
- Cap APOGEE 7/7 préservé (aucun nouveau Neter — sous-domaine Artemis). Aucune donnée Oracle touchée.

https://claude.ai/code/session_011BaRRZ5MBtNiMt4dW2Rgyd

---
_Generated by [Claude Code](https://claude.ai/code/session_011BaRRZ5MBtNiMt4dW2Rgyd)_