### PR TITLE
fix(ui): str() ne produit plus [object Object] dans les renderers bespoke

### DIFF
--- a/src/components/cockpit/pillars/pillar-kit.tsx
+++ b/src/components/cockpit/pillars/pillar-kit.tsx
@@ -47,6 +47,13 @@ export function str(v: unknown): string {
   if (v == null) return "";
   if (typeof v === "string") return v;
   if (typeof v === "number") return v.toLocaleString("fr-FR");
+  if (typeof v === "boolean") return v ? "Oui" : "Non";
+  if (Array.isArray(v)) return (v as unknown[]).map(str).filter(Boolean).join(", ");
+  if (typeof v === "object") {
+    const vals = Object.values(v as Record<string, unknown>);
+    const first = vals.find((x): x is string => typeof x === "string" && x.length > 0);
+    return first ?? vals.map(str).filter(Boolean).join(", ");
+  }
   return String(v);
 }
 


### PR DESCRIPTION
## Summary

- `str()` dans `pillar-kit.tsx` utilisait `String(v)` comme fallback → `[object Object]` pour tout objet ou array
- Tous les renderers bespoke (A/D/V/E/R/T/I/S) héritent de cette fonction → bug visible sur `/positioning` et toutes les pages pilier
- Fix : arrays joints récursivement par `", "`, objets extraient la première valeur string, boolean → "Oui/Non"

## Test plan
- [ ] `/cockpit/brand/positioning` → plus de `[object Object]` sur `tensionProfile`, `lf8Dominant`, etc.
- [ ] `/cockpit/brand/identity` → idem sur `prophecy`, `doctrine`, `enemy`
- [ ] tsc clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)