### PR TITLE
fix(enrich): cible ENRICHED + ladderProductAlignment cross-pillar

### DIFF
--- a/src/components/cockpit/pillar-page.tsx
+++ b/src/components/cockpit/pillar-page.tsx
@@ -256,7 +256,12 @@ export function PillarPage({ pageKey }: PillarPageProps) {
         setEnrichResult({ type: "warning", message: "Pilier dérivé — utilise « Recalculer ce pilier » pour lancer la cascade." });
         return;
       }
-      const r = await autoFillMutation.mutateAsync({ strategyId, pillarKey: config.pillarKey });
+      // Cible ENRICHED (10 champs, 1 chunk LLM, ~10s) et non COMPLETE (23 champs,
+      // 3 chunks, 60s+) : le timeout Vercel tue COMPLETE avant la fin.
+      // Les champs optionnels (sacredCalendar, commandments, sacraments…) sont de
+      // la data cult-marketing spécifique à la marque — ils restent vides jusqu'à
+      // saisie manuelle ou Oracle. ENRICHED = les champs opérationnels essentiels.
+      const r = await autoFillMutation.mutateAsync({ strategyId, pillarKey: config.pillarKey, targetStage: "ENRICHED" });
       const data = r as unknown as Record<string, unknown>;
       const filledCount = Array.isArray(data?.filled) ? (data.filled as string[]).length : 0;
       const failedCount = Array.isArray(data?.failed) ? (data.failed as unknown[]).length : 0;

--- a/src/server/services/pillar-maturity/auto-filler.ts
+++ b/src/server/services/pillar-maturity/auto-filler.ts
@@ -490,6 +490,23 @@ function deriveCrossPillar(
     }
   }
 
+  if (pillarKey === "e") {
+    // ladderProductAlignment : croise V.productLadder (paliers produit) avec les
+    // niveaux de la Devotion Ladder pour produire un mapping entrée/upgrade.
+    if (path === "ladderProductAlignment") {
+      const v = allPillars.v ?? {};
+      const ladder = Array.isArray(v.productLadder) ? (v.productLadder as Array<Record<string, unknown>>) : [];
+      const DEVOTION_LADDER = ["SPECTATEUR", "INTERESSE", "PARTICIPANT", "ENGAGE", "AMBASSADEUR"];
+      if (ladder.length === 0) return undefined;
+      return DEVOTION_LADDER.slice(0, Math.max(2, ladder.length)).map((level, i) => ({
+        devotionLevel: level,
+        productTierRef: typeof ladder[i]?.tier === "string" ? ladder[i]?.tier : undefined,
+        entryAction: ladder[i] ? `Decouvrir ${String(ladder[i]?.tier ?? "ce palier")}` : undefined,
+        upgradeAction: ladder[i + 1] ? `Passer a ${String(ladder[i + 1]?.tier ?? "le palier suivant")}` : undefined,
+      }));
+    }
+  }
+
   if (pillarKey === "r") {
     if (path === "pillarGaps") {
       // Derive from maturity assessment of ADVE


### PR DESCRIPTION
## Summary

- **Timeout Vercel** : `autoFill` ciblait COMPLETE (23 champs, 3 chunks LLM, ~60s) → fonction tuée par Vercel → 504 silencieux → bouton "ne démarre pas". Fix : `targetStage: "ENRICHED"` (10 champs, 1 chunk, ~10s).
- **23 champs échoués** : les champs optionnels cult marketing (sacredCalendar, commandments, sacraments…) nécessitent des données très spécifiques ; LLM retourne JSON partiel → clés manquantes → tout en `failed`. Réservés à saisie manuelle / Oracle.
- **`ladderProductAlignment`** : cross-pillar `E←V.productLadder` déterministe implémenté (évite un fallback LLM coûteux).

## Test plan
- [ ] Cliquer Enrichir sur `/cockpit/brand/engagement` → spinner visible ~10s (plus de timeout)
- [ ] Toast indique champs remplis (aarrr, kpis, touchpoints, rituels, promesseExperience…)
- [ ] `ladderProductAlignment` se remplit si V.productLadder existe

🤖 Generated with [Claude Code](https://claude.com/claude-code)