### PR TITLE
fix(governance): champs cult-marketing E déplacés COMPLETE→ENRICHED

### DIFF
--- a/src/lib/types/pillar-maturity-contracts.ts
+++ b/src/lib/types/pillar-maturity-contracts.ts
@@ -117,6 +117,19 @@ const ENRICHED_E: FieldRequirement[] = [
   // ADR-0037 PR-K3 — fields canon manuel inférables E
   { path: "programmeEvangelisation", validator: "is_object", derivable: true, derivationSource: "ai_generation", description: "Programme d'Évangélisation (manuel E §4.7) — referral/advocacy/recruitment" },
   { path: "communityBuilding", validator: "is_object", derivable: true, derivationSource: "ai_generation", description: "Community Building (manuel E §4.8) — platforms/moderationRules/growthMechanics" },
+  // Champs cult-marketing — 100 % inférables depuis ADVE (A.doctrine/prophecy/valeurs/archetype/enemy, D.personas)
+  // Ajoutés ici (ENRICHED) car ils faisaient partie du pool COMPLETE via schema-derivation mais n'étaient jamais
+  // remplis (3 chunks → timeout Vercel 60s). 2 chunks totaux = ~20s avec ces 10 champs.
+  { path: "sacredCalendar", validator: "min_items", validatorArg: 4, derivable: true, derivationSource: "ai_generation", description: "Calendrier sacré (4+ dates clés de la marque) — dérivé de A.prophecy, A.doctrine" },
+  { path: "commandments", validator: "min_items", validatorArg: 5, derivable: true, derivationSource: "ai_generation", description: "Commandements de la tribu — dérivés de A.doctrine.dogmas + A.valeurs" },
+  { path: "taboos", validator: "min_items", validatorArg: 3, derivable: true, derivationSource: "ai_generation", description: "Tabous communautaires — dérivés de A.enemy + A.doctrine" },
+  { path: "principesCommunautaires", validator: "min_items", validatorArg: 3, derivable: true, derivationSource: "ai_generation", description: "Principes communautaires — dérivés de A.doctrine.principles + A.valeurs" },
+  { path: "ritesDePassage", validator: "min_items", validatorArg: 2, derivable: true, derivationSource: "ai_generation", description: "Rites de passage Devotion Ladder — dérivés de A.hierarchieCommunautaire" },
+  { path: "sacraments", validator: "min_items", validatorArg: 3, derivable: true, derivationSource: "ai_generation", description: "Sacrements (rituels déclencheurs) — dérivés de A.archetype + D.personas" },
+  { path: "gamification", validator: "is_object", derivable: true, derivationSource: "ai_generation", description: "Système de gamification — dérivé de A.hierarchieCommunautaire niveaux" },
+  { path: "barriersEngagement", validator: "min_items", validatorArg: 2, derivable: true, derivationSource: "ai_generation", description: "Barrières d'engagement — dérivées de D.personas.fears + Devotion Ladder" },
+  { path: "clergeStructure", validator: "is_object", derivable: true, derivationSource: "ai_generation", description: "Structure du clergé (community manager, ambassadeurs) — dérivée de A.equipeDirigeante" },
+  { path: "pelerinages", validator: "min_items", validatorArg: 1, derivable: true, derivationSource: "ai_generation", description: "Pèlerinages / événements sacrés — dérivés de A.prophecy + brand events" },
 ];
 
 const ENRICHED_R: FieldRequirement[] = [


### PR DESCRIPTION
## Summary

Les 10 champs cult-marketing du pilier E (`sacredCalendar`, `commandments`, `taboos`, `principesCommunautaires`, `ritesDePassage`, `sacraments`, `gamification`, `barriersEngagement`, `clergeStructure`, `pelerinages`) sont **100 % inférables depuis l'ADVE** mais étaient bloqués en COMPLETE (schema-derivation) :
- 3 chunks LLM séquentiels → timeout Vercel 60s → jamais remplis
- L'utilisateur voyait une boucle : « ces champs nécessitent l'ADVE, mais l'ADVE est vide »

Ce fix les déplace en ENRICHED avec leur dérivation ADVE documentée. Avec `targetStage: "ENRICHED"` du commit précédent : 20 champs total → 2 chunks → ~20s.

## Dérivations ADVE documentées
- `commandments` ← `A.doctrine.dogmas` + `A.valeurs`
- `sacredCalendar` ← `A.prophecy` + `A.doctrine`
- `taboos` ← `A.enemy` + `A.doctrine`
- `sacraments` ← `A.archetype` + `D.personas`
- `ritesDePassage` ← `A.hierarchieCommunautaire`
- `gamification` ← `A.hierarchieCommunautaire` niveaux
- `barriersEngagement` ← `D.personas.fears` + Devotion Ladder
- `clergeStructure` ← `A.equipeDirigeante`
- `pelerinages` ← `A.prophecy` + brand events
- `principesCommunautaires` ← `A.doctrine.principles`

## Test plan
- [ ] Enrichir pilier E avec ADVE rempli → tous les 20 champs ENRICHED se remplissent en ~20s
- [ ] Pas de timeout Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)