### PR TITLE
fix(enrich): chunks LLM parallèles — cible COMPLETE sans timeout Vercel

### DIFF
--- a/src/components/cockpit/pillar-page.tsx
+++ b/src/components/cockpit/pillar-page.tsx
@@ -256,12 +256,7 @@ export function PillarPage({ pageKey }: PillarPageProps) {
         setEnrichResult({ type: "warning", message: "Pilier dérivé — utilise « Recalculer ce pilier » pour lancer la cascade." });
         return;
       }
-      // Cible ENRICHED (10 champs, 1 chunk LLM, ~10s) et non COMPLETE (23 champs,
-      // 3 chunks, 60s+) : le timeout Vercel tue COMPLETE avant la fin.
-      // Les champs optionnels (sacredCalendar, commandments, sacraments…) sont de
-      // la data cult-marketing spécifique à la marque — ils restent vides jusqu'à
-      // saisie manuelle ou Oracle. ENRICHED = les champs opérationnels essentiels.
-      const r = await autoFillMutation.mutateAsync({ strategyId, pillarKey: config.pillarKey, targetStage: "ENRICHED" });
+      const r = await autoFillMutation.mutateAsync({ strategyId, pillarKey: config.pillarKey });
       const data = r as unknown as Record<string, unknown>;
       const filledCount = Array.isArray(data?.filled) ? (data.filled as string[]).length : 0;
       const failedCount = Array.isArray(data?.failed) ? (data.failed as unknown[]).length : 0;

--- a/src/lib/types/pillar-maturity-contracts.ts
+++ b/src/lib/types/pillar-maturity-contracts.ts
@@ -117,19 +117,6 @@ const ENRICHED_E: FieldRequirement[] = [
   // ADR-0037 PR-K3 — fields canon manuel inférables E
   { path: "programmeEvangelisation", validator: "is_object", derivable: true, derivationSource: "ai_generation", description: "Programme d'Évangélisation (manuel E §4.7) — referral/advocacy/recruitment" },
   { path: "communityBuilding", validator: "is_object", derivable: true, derivationSource: "ai_generation", description: "Community Building (manuel E §4.8) — platforms/moderationRules/growthMechanics" },
-  // Champs cult-marketing — 100 % inférables depuis ADVE (A.doctrine/prophecy/valeurs/archetype/enemy, D.personas)
-  // Ajoutés ici (ENRICHED) car ils faisaient partie du pool COMPLETE via schema-derivation mais n'étaient jamais
-  // remplis (3 chunks → timeout Vercel 60s). 2 chunks totaux = ~20s avec ces 10 champs.
-  { path: "sacredCalendar", validator: "min_items", validatorArg: 4, derivable: true, derivationSource: "ai_generation", description: "Calendrier sacré (4+ dates clés de la marque) — dérivé de A.prophecy, A.doctrine" },
-  { path: "commandments", validator: "min_items", validatorArg: 5, derivable: true, derivationSource: "ai_generation", description: "Commandements de la tribu — dérivés de A.doctrine.dogmas + A.valeurs" },
-  { path: "taboos", validator: "min_items", validatorArg: 3, derivable: true, derivationSource: "ai_generation", description: "Tabous communautaires — dérivés de A.enemy + A.doctrine" },
-  { path: "principesCommunautaires", validator: "min_items", validatorArg: 3, derivable: true, derivationSource: "ai_generation", description: "Principes communautaires — dérivés de A.doctrine.principles + A.valeurs" },
-  { path: "ritesDePassage", validator: "min_items", validatorArg: 2, derivable: true, derivationSource: "ai_generation", description: "Rites de passage Devotion Ladder — dérivés de A.hierarchieCommunautaire" },
-  { path: "sacraments", validator: "min_items", validatorArg: 3, derivable: true, derivationSource: "ai_generation", description: "Sacrements (rituels déclencheurs) — dérivés de A.archetype + D.personas" },
-  { path: "gamification", validator: "is_object", derivable: true, derivationSource: "ai_generation", description: "Système de gamification — dérivé de A.hierarchieCommunautaire niveaux" },
-  { path: "barriersEngagement", validator: "min_items", validatorArg: 2, derivable: true, derivationSource: "ai_generation", description: "Barrières d'engagement — dérivées de D.personas.fears + Devotion Ladder" },
-  { path: "clergeStructure", validator: "is_object", derivable: true, derivationSource: "ai_generation", description: "Structure du clergé (community manager, ambassadeurs) — dérivée de A.equipeDirigeante" },
-  { path: "pelerinages", validator: "min_items", validatorArg: 1, derivable: true, derivationSource: "ai_generation", description: "Pèlerinages / événements sacrés — dérivés de A.prophecy + brand events" },
 ];
 
 const ENRICHED_R: FieldRequirement[] = [

--- a/src/server/services/pillar-maturity/auto-filler.ts
+++ b/src/server/services/pillar-maturity/auto-filler.ts
@@ -806,24 +806,28 @@ export async function runChunkedFieldGeneration(args: {
     });
   }
 
-  // Multi-chunk path — round-robin split, sequential calls, merge.
+  // Multi-chunk path — round-robin split, appels PARALLÈLES, merge.
+  // Avant : séquentiel → N chunks × 20-30s = timeout Vercel 60s sur les piliers
+  // complexes (E = 23 champs = 3 chunks = 90s). Après : parallèle → max(chunk_time)
+  // = ~25-30s quel que soit N. Les chunks sont indépendants (champs distincts,
+  // contexte pilier identique) donc la parallélisation est safe.
   const chunks = chunkFields(missingReqs, fieldsPerChunk);
-  const merged: Record<string, unknown> = {};
-  for (let i = 0; i < chunks.length; i++) {
-    const result = await runChunkLLM({
-      strategyId,
-      pillarKey,
-      chunk: chunks[i]!,
-      pillarContext,
-      financialCtx,
-      hasFinancialFields,
-      caller: `${callerBase}:chunk-${i + 1}/${chunks.length}`,
-      maxOutputTokens: 3000,
-      ollamaModel: args.ollamaModel,
-    });
-    Object.assign(merged, result);
-  }
-  return merged;
+  const results = await Promise.all(
+    chunks.map((chunk, i) =>
+      runChunkLLM({
+        strategyId,
+        pillarKey,
+        chunk,
+        pillarContext,
+        financialCtx,
+        hasFinancialFields,
+        caller: `${callerBase}:chunk-${i + 1}/${chunks.length}`,
+        maxOutputTokens: 4000,
+        ollamaModel: args.ollamaModel,
+      }),
+    ),
+  );
+  return Object.assign({}, ...results);
 }
 
 async function generateMissingFields(


### PR DESCRIPTION
## Diagnostic

Le bouton Enrichir ciblait COMPLETE correctement, mais les chunks LLM étaient **séquentiels** :
- Pilier E : 23 champs → 3 chunks × ~25s/chunk = **75s → timeout Vercel 60s**
- Résultat : fonction tuée, 504 silencieux, spinner invisible, "le bouton ne démarre pas"

## Fix

`Promise.all` sur les chunks : les champs de chaque chunk sont **indépendants** (même contexte pilier, champs distincts) → parallélisation safe.

```
Avant : chunk1 → chunk2 → chunk3  =  75s  ❌ timeout
Après : chunk1 ⎤
        chunk2 ⎥→ merge  =  ~25s  ✓
        chunk3 ⎦
```

- Reverts les workarounds précédents (`targetStage: "ENRICHED"` + promotion cult fields) qui violaient le principe de La Fusée : **le cockpit vise toujours COMPLETE, tout se remplit en une passe**
- `maxOutputTokens` 3000→4000 par chunk pour réduire les JSON tronqués
- ENRICHED reste réservé à l'intake

## Test plan
- [ ] Enrichir pilier E (page vide) → spinner ~25s, tous les 23 champs remplis
- [ ] Pas de timeout sur aucun pilier

🤖 Generated with [Claude Code](https://claude.com/claude-code)